### PR TITLE
fix(starter): pull in -spring-boot as a transitive dependency

### DIFF
--- a/README.ru.md
+++ b/README.ru.md
@@ -316,7 +316,7 @@ public class GigaChatService {
 
 #### Поддерживаемые внешние стартеры
 
-| Стартер   | Артефакт                                     | ChatModel                                                            | EmbeddingModel              |
+|  Стартер  |                   Артефакт                   |                              ChatModel                               |       EmbeddingModel        |
 |-----------|----------------------------------------------|----------------------------------------------------------------------|-----------------------------|
 | GigaChat  | `chat.giga:spring-ai-starter-model-gigachat` | GigaChat, GigaChat-Pro, GigaChat-Max, GigaChat-2-Pro, GigaChat-2-Max | Embeddings, EmbeddingsGigaR |
 | Anthropic | `spring-ai-starter-model-anthropic`          | Claude                                                               | -                           |
@@ -357,7 +357,7 @@ LLM-as-judge даёт нестабильные оценки, если крите
 
 Метрики возвращают значения в разных диапазонах — пороги надо подбирать с учётом этого:
 
-| Метрика                                                                  | Диапазон                                 | Рекомендуемый порог                        |
+|                                 Метрика                                  |                 Диапазон                 |            Рекомендуемый порог             |
 |--------------------------------------------------------------------------|------------------------------------------|--------------------------------------------|
 | `AspectCriticMetric`, `ToolCallAccuracyMetric`                           | бинарный 0 / 1                           | `isEqualTo(1.0)`                           |
 | `SimpleCriteriaScoreMetric`                                              | [0..1] (нормализуется из raw)            | `>= 0.75` (raw 4/5) или `== 1.0` (raw 5/5) |

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
             </dependency>
             <dependency>
                 <groupId>io.github.ai-qa-solutions</groupId>
+                <artifactId>spring-ai-ragas-spring-boot</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.ai-qa-solutions</groupId>
                 <artifactId>spring-ai-ragas-allure</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/spring-ai-ragas-spring-boot-starter/pom.xml
+++ b/spring-ai-ragas-spring-boot-starter/pom.xml
@@ -15,4 +15,18 @@
     <description>Spring Boot starter for RAGAS metrics evaluation</description>
     <url>https://github.com/ai-qa-solutions/spring-ai-ragas</url>
 
+    <dependencies>
+        <!--
+             Pulls in the autoconfiguration module, which transitively brings
+             spring-ai-ragas-metrics, spring-ai-ragas-multi-model, bucket4j-core
+             and Spring Boot autoconfigure support. Adding this starter alone
+             must be enough to use any RAGAS metric in a Spring Boot project.
+             Version is managed by the parent pom's dependencyManagement.
+        -->
+        <dependency>
+            <groupId>io.github.ai-qa-solutions</groupId>
+            <artifactId>spring-ai-ragas-spring-boot</artifactId>
+        </dependency>
+    </dependencies>
+
 </project>


### PR DESCRIPTION
## Summary

Fixes the empty POM in `spring-ai-ragas-spring-boot-starter` — the starter shipped in `0.3.1` had no `<dependencies>` block, so adding it alone did not bring metric classes, autoconfiguration or multi-model runtime. Every project following the README verbatim failed at compile time with `cannot find symbol: class AspectCriticMetric` and similar errors for each metric type.

## Changes

- Add a single dependency on `spring-ai-ragas-spring-boot` in the starter pom — it transitively pulls in `-metrics`, `-multi-model`, `bucket4j-core` and Spring Boot autoconfigure support.
- Register `spring-ai-ragas-spring-boot` in the parent pom's dependencyManagement so the starter can omit the version tag and stay consistent with the rest of the reactor.
- Incidental: spotless pass re-centered two table headers in README.ru.md. Kept as a separate commit.

## Verification

Downstream demo project with only the starter as the RAGAS dependency:

- `mvn dependency:tree` shows the transitive chain `starter -> spring-boot -> metrics, multi-model, bucket4j-core`
- Compile succeeds
- All tests (11 + 9 metrics) pass against real GigaChat-2-Max
- Full repo `mvn verify` green: all 6 reactor modules SUCCESS, 54 tests in spring-ai-ragas-spring-boot pass

## Related

Fixes #7.
