### PR TITLE
chore: bump spring-boot 3.5.11 → 3.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.11</version>
+        <version>3.5.13</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
## Summary
- Bump `spring-boot-starter-parent` from `3.5.11` to `3.5.13` (latest 3.5.x patch).

## Test plan
- [ ] CI green across all reactor modules
