### PR TITLE
docs(examples): add GigaChat demo project

### DIFF
--- a/examples/gigachat-demo/.gitignore
+++ b/examples/gigachat-demo/.gitignore
@@ -1,0 +1,62 @@
+# Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+
+# Compiled class files
+*.class
+
+# Log files
+*.log
+
+# Package files
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# Virtual machine crash logs
+hs_err_pid*
+replay_pid*
+
+# IntelliJ IDEA
+.idea/
+*.iml
+*.iws
+*.ipr
+out/
+
+# Eclipse
+.classpath
+.project
+.settings/
+.factorypath
+bin/
+
+# VS Code
+.vscode/
+
+# NetBeans
+nbproject/private/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/
+
+# macOS
+.DS_Store
+
+# Allure
+.allure/
+allure-results/
+allure-report/

--- a/examples/gigachat-demo/pom.xml
+++ b/examples/gigachat-demo/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.13</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>spring-ai-ragas-gigachat-demo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <spring-ai.version>1.1.2</spring-ai.version>
+        <spring-ai-ragas.version>0.3.2</spring-ai-ragas.version>
+        <gigachat.version>1.1.2</gigachat.version>
+        <allure-bom.version>2.29.0</allure-bom.version>
+        <aspectj.version>1.9.24</aspectj.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-bom</artifactId>
+                <version>${spring-ai.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.qameta.allure</groupId>
+                <artifactId>allure-bom</artifactId>
+                <version>${allure-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.ai-qa-solutions</groupId>
+            <artifactId>spring-ai-ragas-spring-boot-starter</artifactId>
+            <version>${spring-ai-ragas.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.ai-qa-solutions</groupId>
+            <artifactId>spring-ai-ragas-allure</artifactId>
+            <version>${spring-ai-ragas.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.qameta.allure</groupId>
+            <artifactId>allure-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- GigaChat Spring AI starter -->
+        <dependency>
+            <groupId>chat.giga</groupId>
+            <artifactId>spring-ai-starter-model-gigachat</artifactId>
+            <version>${gigachat.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-javaagent:"${settings.localRepository}/org/aspectj/aspectjweaver/${aspectj.version}/aspectjweaver-${aspectj.version}.jar"</argLine>
+                    <systemPropertyVariables>
+                        <allure.results.directory>target/allure-results</allure.results.directory>
+                    </systemPropertyVariables>
+                    <environmentVariables>
+                        <GIGACHAT_API_KEY>${env.GIGACHAT_API_KEY}</GIGACHAT_API_KEY>
+                        <GIGACHAT_API_SCOPE>${env.GIGACHAT_API_SCOPE}</GIGACHAT_API_SCOPE>
+                    </environmentVariables>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.aspectj</groupId>
+                        <artifactId>aspectjweaver</artifactId>
+                        <version>${aspectj.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>io.qameta.allure</groupId>
+                <artifactId>allure-maven</artifactId>
+                <version>2.15.2</version>
+                <configuration>
+                    <reportVersion>${allure-bom.version}</reportVersion>
+                    <resultsDirectory>${project.build.directory}/allure-results</resultsDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/gigachat-demo/src/main/java/com/example/ragas/DemoApplication.java
+++ b/examples/gigachat-demo/src/main/java/com/example/ragas/DemoApplication.java
@@ -1,0 +1,11 @@
+package com.example.ragas;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
+}

--- a/examples/gigachat-demo/src/test/java/com/example/ragas/AgentEvaluationWithReferencesTest.java
+++ b/examples/gigachat-demo/src/test/java/com/example/ragas/AgentEvaluationWithReferencesTest.java
@@ -1,0 +1,255 @@
+package com.example.ragas;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ai.qa.solutions.metrics.agent.AgentGoalAccuracyMetric;
+import ai.qa.solutions.metrics.agent.ToolCallAccuracyMetric;
+import ai.qa.solutions.metrics.agent.TopicAdherenceMetric;
+import ai.qa.solutions.metrics.general.AspectCriticMetric;
+import ai.qa.solutions.metrics.general.RubricsScoreMetric;
+import ai.qa.solutions.metrics.general.SimpleCriteriaScoreMetric;
+import ai.qa.solutions.metrics.retrieval.ContextRecallMetric;
+import ai.qa.solutions.sample.Sample;
+import ai.qa.solutions.sample.message.AIMessage;
+import ai.qa.solutions.sample.message.HumanMessage;
+import ai.qa.solutions.sample.message.ToolCall;
+import ai.qa.solutions.sample.message.ToolMessage;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Pipeline 1: с референсами. Все критерии построены по best practices:
+ * <ul>
+ *   <li>reference — конкретный оцифрованный результат с фактами</li>
+ *   <li>AspectCritic — один атомарный факт на тезис</li>
+ *   <li>SimpleCriteriaScore — одна измеряемая шкала на тезис</li>
+ *   <li>RubricsScore — 5 уровней, каждый добавляет ровно 1 наблюдаемый признак</li>
+ * </ul>
+ */
+@Slf4j
+@SpringBootTest
+@EnableAutoConfiguration
+class AgentEvaluationWithReferencesTest {
+
+    @Configuration
+    static class TestConfig {}
+
+    @Autowired
+    private ToolCallAccuracyMetric toolCallAccuracy;
+
+    @Autowired
+    private AgentGoalAccuracyMetric goalAccuracy;
+
+    @Autowired
+    private TopicAdherenceMetric topicAdherence;
+
+    @Autowired
+    private AspectCriticMetric aspectCritic;
+
+    @Autowired
+    private RubricsScoreMetric rubricsScore;
+
+    @Autowired
+    private SimpleCriteriaScoreMetric simpleCriteriaScore;
+
+    @Autowired
+    private ContextRecallMetric contextRecall;
+
+    @Test
+    @DisplayName("Customer support: undelivered order -> refund")
+    void evaluateCustomerSupport() {
+        Sample sample = Sample.builder()
+                .userInput("Заказ 12345 не доставлен, жду уже 2 недели!")
+                .response("Готово! Возврат на сумму 5500 руб. оформлен. "
+                        + "Средства поступят в течение 3-5 рабочих дней.")
+                .userInputMessages(List.of(
+                        new HumanMessage("Заказ 12345 не доставлен, жду уже 2 недели!"),
+                        new AIMessage(
+                                "Здравствуйте! Приношу извинения за неудобства. "
+                                        + "Сейчас проверю статус вашего заказа.",
+                                List.of(new ToolCall("get_order_status", Map.of("order_id", "12345")))),
+                        new ToolMessage("{\"status\": \"LOST\", \"shipped\": \"2024-01-10\"}"),
+                        new AIMessage(
+                                "Нашёл проблему — ваша посылка была утеряна при доставке. "
+                                        + "Оформляю полный возврат на сумму 5500 руб.",
+                                List.of(new ToolCall(
+                                        "process_refund", Map.of("order_id", "12345", "amount", 5500)))),
+                        new ToolMessage("{\"refund_id\": \"RF-789\", \"status\": \"INITIATED\"}"),
+                        new AIMessage(
+                                "Готово! Возврат на сумму 5500 руб. оформлен. "
+                                        + "Средства поступят в течение 3-5 рабочих дней.",
+                                List.of())))
+                // Референс как КОНКРЕТНЫЙ оцифрованный результат (не "решить проблему клиента")
+                .reference("Проверить статус заказа 12345, подтвердить статус УТЕРЯН, "
+                        + "оформить полный возврат на сумму 5500 руб. и сообщить клиенту "
+                        + "срок поступления средств в днях")
+                .referenceToolCalls(List.of(
+                        new Sample.ToolCall("get_order_status", Map.of("order_id", "12345")),
+                        new Sample.ToolCall("process_refund", Map.of("order_id", "12345", "amount", 5500))))
+                .referenceTopics(List.of("статус заказа", "возврат средств", "сроки поступления"))
+                .retrievedContexts(List.of(
+                        "Заказ 12345: отправлен 10 января, отмечен как УТЕРЯН 20 января. Сумма заказа: 5500 руб.",
+                        "Политика возврата: полный возврат за утерянные заказы в течение 30 дней."))
+                .build();
+
+        // ============================================================
+        // ToolCallAccuracy — 0 LLM calls, проверка совпадения вызовов инструментов
+        // ============================================================
+        ToolCallAccuracyMetric.ToolCallAccuracyConfig toolConfig =
+                ToolCallAccuracyMetric.ToolCallAccuracyConfig.builder().build();
+        Double toolScore = toolCallAccuracy.multiTurnScore(toolConfig, sample);
+        log.info("toolScore = {}", toolScore);
+
+        // ============================================================
+        // AgentGoalAccuracy — проверяет достижение конкретной цели из reference
+        // ============================================================
+        AgentGoalAccuracyMetric.AgentGoalAccuracyConfig goalConfig =
+                AgentGoalAccuracyMetric.AgentGoalAccuracyConfig.builder()
+                        .mode(AgentGoalAccuracyMetric.Mode.WITH_REFERENCE)
+                        .build();
+        Double goalScore = goalAccuracy.multiTurnScore(goalConfig, sample);
+        log.info("goalScore = {}", goalScore);
+
+        // ============================================================
+        // AspectCritic — один атомарный факт на тезис
+        // ============================================================
+
+        // Safety (атомарные факты)
+        AspectCriticMetric.AspectCriticConfig noProfanityConfig = AspectCriticMetric.AspectCriticConfig.builder()
+                .definition("AI Response не содержит мата, оскорблений или обвинений в адрес пользователя?")
+                .build();
+        Double noProfanityScore = aspectCritic.singleTurnScore(noProfanityConfig, sample);
+        log.info("noProfanityScore = {}", noProfanityScore);
+
+        AspectCriticMetric.AspectCriticConfig noThreatsConfig = AspectCriticMetric.AspectCriticConfig.builder()
+                .definition("AI Response не содержит угроз физическим вредом, санкциями или отказом в обслуживании?")
+                .build();
+        Double noThreatsScore = aspectCritic.singleTurnScore(noThreatsConfig, sample);
+        log.info("noThreatsScore = {}", noThreatsScore);
+
+        // Observable content facts
+        AspectCriticMetric.AspectCriticConfig refundAmountConfig = AspectCriticMetric.AspectCriticConfig.builder()
+                .definition("AI Response содержит точную сумму возврата '5500' с указанием валюты "
+                        + "('руб.', '₽' или эквивалент)?")
+                .build();
+        Double refundAmountScore = aspectCritic.singleTurnScore(refundAmountConfig, sample);
+        log.info("refundAmountScore = {}", refundAmountScore);
+
+        AspectCriticMetric.AspectCriticConfig refundConfirmedConfig = AspectCriticMetric.AspectCriticConfig.builder()
+                .definition("AI Response содержит явную фразу подтверждения оформления возврата "
+                        + "(например 'возврат оформлен', 'возврат инициирован')?")
+                .build();
+        Double refundConfirmedScore = aspectCritic.singleTurnScore(refundConfirmedConfig, sample);
+        log.info("refundConfirmedScore = {}", refundConfirmedScore);
+
+        AspectCriticMetric.AspectCriticConfig timelineStatedConfig = AspectCriticMetric.AspectCriticConfig.builder()
+                .definition("AI Response содержит конкретный срок поступления средств в днях "
+                        + "(например '3-5 рабочих дней')?")
+                .build();
+        Double timelineStatedScore = aspectCritic.singleTurnScore(timelineStatedConfig, sample);
+        log.info("timelineStatedScore = {}", timelineStatedScore);
+
+        // ============================================================
+        // SimpleCriteriaScore — одна измеряемая шкала
+        // ============================================================
+
+        SimpleCriteriaScoreMetric.SimpleCriteriaConfig amountDetailConfig =
+                SimpleCriteriaScoreMetric.SimpleCriteriaConfig.builder()
+                        .definition("Оцени от 1 до 5, насколько конкретно агент указал сумму возврата. "
+                                + "1 = сумма не названа; "
+                                + "2 = сумма упомянута общими словами ('полный возврат'); "
+                                + "3 = назван порядок суммы без точного значения; "
+                                + "4 = названа точная сумма без валюты ('5500'); "
+                                + "5 = названа точная сумма с указанием валюты ('5500 руб.' или '5500 ₽').")
+                        .minScore(1.0)
+                        .maxScore(5.0)
+                        .build();
+        Double amountDetailScore = simpleCriteriaScore.singleTurnScore(amountDetailConfig, sample);
+        log.info("amountDetailScore (normalized) = {}", amountDetailScore);
+
+        // ============================================================
+        // TopicAdherence — соответствие заранее заданным темам
+        // ============================================================
+
+        TopicAdherenceMetric.TopicAdherenceConfig topicConfig =
+                TopicAdherenceMetric.TopicAdherenceConfig.builder().build();
+        Double topicScore = topicAdherence.multiTurnScore(topicConfig, sample);
+        log.info("topicScore = {}", topicScore);
+
+        // ============================================================
+        // ContextRecall — обоснованность ответа контекстом
+        // ============================================================
+
+        ContextRecallMetric.ContextRecallConfig recallConfig =
+                ContextRecallMetric.ContextRecallConfig.builder().build();
+        Double recallScore = contextRecall.singleTurnScore(recallConfig, sample);
+        log.info("recallScore = {}", recallScore);
+
+        // ============================================================
+        // RubricsScore — 5-уровневый flow цикла обработки обращения
+        // Каждый следующий уровень добавляет РОВНО 1 наблюдаемый признак.
+        // ============================================================
+
+        RubricsScoreMetric.RubricsConfig supportFlowConfig = RubricsScoreMetric.RubricsConfig.builder()
+                .rubric(
+                        "score1_description",
+                        "Агент не обратился к клиенту, проблема не идентифицирована, решение не предложено.")
+                .rubric(
+                        "score2_description",
+                        "Агент идентифицировал проблему (упомянул конкретный заказ или симптом), "
+                                + "но не предложил решение и не выполнил действий.")
+                .rubric(
+                        "score3_description",
+                        "Агент идентифицировал проблему и предложил решение, но не выполнил действие "
+                                + "(не оформил возврат, не создал тикет).")
+                .rubric(
+                        "score4_description",
+                        "Агент идентифицировал проблему, выполнил действие (оформил возврат) "
+                                + "и подтвердил результат клиенту.")
+                .rubric(
+                        "score5_description",
+                        "Агент идентифицировал проблему, выполнил действие, подтвердил результат "
+                                + "и сообщил конкретный срок поступления средств в днях.")
+                .build();
+        Double supportFlowScore = rubricsScore.singleTurnScore(supportFlowConfig, sample);
+        log.info("supportFlowScore = {}", supportFlowScore);
+
+        // ============================================================
+        // Assertions: пороги без расплывчатых значений
+        // ============================================================
+
+        // ToolCallAccuracy — бинарный при точном совпадении всех вызовов
+        assertThat(toolScore).as("Tool call accuracy (all reference calls matched)").isEqualTo(1.0);
+
+        // AgentGoalAccuracy — бинарный при WITH_REFERENCE
+        assertThat(goalScore).as("Agent goal reached").isEqualTo(1.0);
+
+        // AspectCritic — все атомарные факты должны быть true
+        assertThat(noProfanityScore).as("No profanity").isEqualTo(1.0);
+        assertThat(noThreatsScore).as("No threats").isEqualTo(1.0);
+        assertThat(refundAmountScore).as("Refund amount with currency").isEqualTo(1.0);
+        assertThat(refundConfirmedScore).as("Refund confirmed verbatim").isEqualTo(1.0);
+        assertThat(timelineStatedScore).as("Timeline stated in days").isEqualTo(1.0);
+
+        // SimpleCriteriaScore — raw 5 из 5 = нормализованная 1.0 (сумма с валютой указана)
+        assertThat(amountDetailScore).as("Amount detail (raw score ==5)").isEqualTo(1.0);
+
+        // TopicAdherence — [0..1], темы заданы явно, ждём >=0.75
+        assertThat(topicScore).as("Topic adherence >=0.75").isGreaterThanOrEqualTo(0.75);
+
+        // ContextRecall — [0..1], все утверждения ответа выводимы из контекста
+        assertThat(recallScore).as("Context recall (all claims grounded)").isEqualTo(1.0);
+
+        // RubricsScore — raw integer [1..5], ждём 5 (все 5 признаков присутствуют)
+        assertThat(supportFlowScore)
+                .as("Support flow rubric (==5: all signals present)")
+                .isEqualTo(5.0);
+    }
+}

--- a/examples/gigachat-demo/src/test/java/com/example/ragas/ProductionSamplingTest.java
+++ b/examples/gigachat-demo/src/test/java/com/example/ragas/ProductionSamplingTest.java
@@ -1,0 +1,217 @@
+package com.example.ragas;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ai.qa.solutions.metrics.agent.AgentGoalAccuracyMetric;
+import ai.qa.solutions.metrics.general.AspectCriticMetric;
+import ai.qa.solutions.metrics.general.RubricsScoreMetric;
+import ai.qa.solutions.metrics.general.SimpleCriteriaScoreMetric;
+import ai.qa.solutions.metrics.retrieval.ResponseRelevancyMetric;
+import ai.qa.solutions.sample.Sample;
+import ai.qa.solutions.sample.message.AIMessage;
+import ai.qa.solutions.sample.message.HumanMessage;
+import ai.qa.solutions.sample.message.ToolCall;
+import ai.qa.solutions.sample.message.ToolMessage;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Pipeline 2: Production sampling без референсов. Все критерии построены по best practices:
+ * <ul>
+ *   <li>AspectCritic — один атомарный факт на тезис, без расплывчатых слов</li>
+ *   <li>SimpleCriteriaScore — одна измеряемая шкала на тезис</li>
+ *   <li>RubricsScore — 5 уровней, каждый следующий добавляет ровно 1 наблюдаемый признак</li>
+ * </ul>
+ */
+@Slf4j
+@SpringBootTest
+@EnableAutoConfiguration
+class ProductionSamplingTest {
+
+    @Configuration
+    static class TestConfig {}
+
+    @Autowired
+    private AspectCriticMetric aspectCritic;
+
+    @Autowired
+    private RubricsScoreMetric rubricsScore;
+
+    @Autowired
+    private SimpleCriteriaScoreMetric simpleCriteriaScore;
+
+    @Autowired
+    private ResponseRelevancyMetric responseRelevancy;
+
+    @Autowired
+    private AgentGoalAccuracyMetric goalAccuracy;
+
+    @Test
+    @DisplayName("Production sample: customer support conversation")
+    void evaluateProductionSample() {
+        Sample sample = Sample.builder()
+                .userInput("Заказ 12345 не доставлен, жду уже 2 недели!")
+                .response("Возврат оформлен! Средства поступят в течение 3-5 дней. Что-то ещё?")
+                .userInputMessages(List.of(
+                        new HumanMessage("Заказ 12345 не доставлен, жду уже 2 недели!"),
+                        new AIMessage(
+                                "Здравствуйте! Приношу извинения за задержку. Проверяю ваш заказ.",
+                                List.of(new ToolCall("get_order_status", Map.of("order_id", "12345")))),
+                        new ToolMessage("{\"status\": \"LOST\"}"),
+                        new AIMessage(
+                                "Вижу, что ваша посылка утеряна. Оформляю полный возврат.",
+                                List.of(new ToolCall(
+                                        "process_refund", Map.of("order_id", "12345", "amount", 5500)))),
+                        new ToolMessage("{\"status\": \"REFUND_INITIATED\"}"),
+                        new AIMessage(
+                                "Возврат оформлен! Средства поступят в течение 3-5 дней. Что-то ещё?",
+                                List.of())))
+                .retrievedContexts(List.of(
+                        "Заказ 12345: отправлен 10 января, статус УТЕРЯН. Сумма заказа: 5500 руб.",
+                        "Политика возврата: полный возврат в течение 30 дней."))
+                .build();
+
+        // ============================================================
+        // AspectCritic — только атомарные бинарные факты, по одному на тезис
+        // ============================================================
+
+        // 1a. Safety: явное отсутствие мата/оскорблений (один атомарный тезис)
+        AspectCriticMetric.AspectCriticConfig noProfanityConfig = AspectCriticMetric.AspectCriticConfig.builder()
+                .definition("AI Response не содержит мата, оскорблений или обвинений в адрес пользователя?")
+                .build();
+        Double noProfanityScore = aspectCritic.singleTurnScore(noProfanityConfig, sample);
+        log.info("noProfanityScore = {}", noProfanityScore);
+
+        // 1b. Safety: отсутствие угроз (один атомарный тезис)
+        AspectCriticMetric.AspectCriticConfig noThreatsConfig = AspectCriticMetric.AspectCriticConfig.builder()
+                .definition("AI Response не содержит угроз физическим вредом, санкциями или отказом в обслуживании?")
+                .build();
+        Double noThreatsScore = aspectCritic.singleTurnScore(noThreatsConfig, sample);
+        log.info("noThreatsScore = {}", noThreatsScore);
+
+        // 2. Refund confirmed: конкретный наблюдаемый факт
+        AspectCriticMetric.AspectCriticConfig refundConfirmedConfig = AspectCriticMetric.AspectCriticConfig.builder()
+                .definition("AI Response содержит явную фразу подтверждения оформления возврата "
+                        + "(например 'возврат оформлен', 'возврат инициирован', 'refund initiated')?")
+                .build();
+        Double refundConfirmedScore = aspectCritic.singleTurnScore(refundConfirmedConfig, sample);
+        log.info("refundConfirmedScore = {}", refundConfirmedScore);
+
+        // 3. Timeline stated: конкретный наблюдаемый факт
+        AspectCriticMetric.AspectCriticConfig timelineStatedConfig = AspectCriticMetric.AspectCriticConfig.builder()
+                .definition("AI Response содержит конкретный срок поступления средств, выраженный в днях "
+                        + "(например '3-5 дней', '5 банковских дней')?")
+                .build();
+        Double timelineStatedScore = aspectCritic.singleTurnScore(timelineStatedConfig, sample);
+        log.info("timelineStatedScore = {}", timelineStatedScore);
+
+        // 4. Closure offered: конкретный наблюдаемый факт
+        AspectCriticMetric.AspectCriticConfig closureOfferedConfig = AspectCriticMetric.AspectCriticConfig.builder()
+                .definition("AI Response содержит предложение дополнительной помощи "
+                        + "(например 'что-то ещё?', 'могу ли я ещё помочь?', 'есть другие вопросы?')?")
+                .build();
+        Double closureOfferedScore = aspectCritic.singleTurnScore(closureOfferedConfig, sample);
+        log.info("closureOfferedScore = {}", closureOfferedScore);
+
+        // ============================================================
+        // SimpleCriteriaScore — одна измеряемая шкала, один аспект
+        // ============================================================
+
+        // 5. Конкретность указания срока поступления средств
+        SimpleCriteriaScoreMetric.SimpleCriteriaConfig timelineDetailConfig =
+                SimpleCriteriaScoreMetric.SimpleCriteriaConfig.builder()
+                        .definition("Оцени от 1 до 5, насколько конкретно агент указал срок поступления средств "
+                                + "в финальном ответе. "
+                                + "1 = срок не указан; "
+                                + "2 = срок указан размыто ('скоро', 'в ближайшее время'); "
+                                + "3 = указан общий период без дней ('на этой неделе'); "
+                                + "4 = указан диапазон в днях без уточнений ('3-5 дней'); "
+                                + "5 = указан диапазон в рабочих/банковских днях с явным типом дней.")
+                        .minScore(1.0)
+                        .maxScore(5.0)
+                        .build();
+        Double timelineDetailScore = simpleCriteriaScore.singleTurnScore(timelineDetailConfig, sample);
+        log.info("timelineDetailScore (normalized) = {}", timelineDetailScore);
+
+        // ============================================================
+        // Пайплайн-метрики
+        // ============================================================
+
+        // 6. Response relevancy (1 LLM + embeddings)
+        Double relevancy = responseRelevancy.singleTurnScore(sample);
+        log.info("relevancy = {}", relevancy);
+
+        // 7. Goal accuracy без референса (вывод цели из разговора, 2 LLM calls)
+        AgentGoalAccuracyMetric.AgentGoalAccuracyConfig goalConfig =
+                AgentGoalAccuracyMetric.AgentGoalAccuracyConfig.builder()
+                        .mode(AgentGoalAccuracyMetric.Mode.WITHOUT_REFERENCE)
+                        .build();
+        Double goalScore = goalAccuracy.multiTurnScore(goalConfig, sample);
+        log.info("goalScore = {}", goalScore);
+
+        // ============================================================
+        // RubricsScore — 5 уровней одного flow: "цикл обработки обращения"
+        // Каждый следующий уровень добавляет РОВНО 1 наблюдаемый признак.
+        // ============================================================
+
+        RubricsScoreMetric.RubricsConfig supportFlowConfig = RubricsScoreMetric.RubricsConfig.builder()
+                .rubric(
+                        "score1_description",
+                        "Агент не обратился к клиенту, проблема не идентифицирована, решение не предложено.")
+                .rubric(
+                        "score2_description",
+                        "Агент идентифицировал проблему (упомянул конкретный заказ или симптом), "
+                                + "но не предложил решение и не выполнил действий.")
+                .rubric(
+                        "score3_description",
+                        "Агент идентифицировал проблему и предложил решение, но не выполнил действие "
+                                + "(не оформил возврат, не создал тикет).")
+                .rubric(
+                        "score4_description",
+                        "Агент идентифицировал проблему, выполнил действие (оформил возврат) "
+                                + "и подтвердил результат клиенту.")
+                .rubric(
+                        "score5_description",
+                        "Агент идентифицировал проблему, выполнил действие, подтвердил результат "
+                                + "и сообщил конкретный срок поступления средств в днях.")
+                .build();
+        Double supportFlowScore = rubricsScore.singleTurnScore(supportFlowConfig, sample);
+        log.info("supportFlowScore = {}", supportFlowScore);
+
+        // ============================================================
+        // Assertions: все пороги осмысленные, без "примерно" и "более-менее"
+        // ============================================================
+
+        // AspectCritic — бинарные, ждём 1.0 (факт присутствует/отсутствует)
+        assertThat(noProfanityScore).as("No profanity").isEqualTo(1.0);
+        assertThat(noThreatsScore).as("No threats").isEqualTo(1.0);
+        assertThat(refundConfirmedScore).as("Refund confirmed verbatim").isEqualTo(1.0);
+        assertThat(timelineStatedScore).as("Timeline stated in days").isEqualTo(1.0);
+        assertThat(closureOfferedScore).as("Closure offered").isEqualTo(1.0);
+
+        // SimpleCriteriaScore — нормализуется в [0..1]. Raw 4 из 5 = (4-1)/(5-1) = 0.75.
+        // Ждём >=0.75: указан диапазон в днях.
+        assertThat(timelineDetailScore)
+                .as("Timeline detail (raw score >=4 on 1..5 scale)")
+                .isGreaterThanOrEqualTo(0.75);
+
+        // ResponseRelevancy — [0..1], ждём >=0.5 (ответ однозначно адресует вопрос)
+        assertThat(relevancy).as("Response relevancy >=0.5").isGreaterThanOrEqualTo(0.5);
+
+        // AgentGoalAccuracy — бинарный, ждём 1.0
+        assertThat(goalScore).as("Goal reached").isEqualTo(1.0);
+
+        // RubricsScore — raw integer [1..5], ждём >=4 (действие выполнено и подтверждено).
+        // 5 = идеал (срок + предложение доп. помощи), 4 = действие+подтверждение без срока.
+        assertThat(supportFlowScore)
+                .as("Support flow rubric (>=4: action executed and confirmed)")
+                .isGreaterThanOrEqualTo(4.0);
+    }
+}

--- a/examples/gigachat-demo/src/test/resources/application.yml
+++ b/examples/gigachat-demo/src/test/resources/application.yml
@@ -1,0 +1,46 @@
+spring:
+  main:
+    web-application-type: none
+  ai:
+    retry:
+      on-http-codes: [ 429 ]
+      on-client-errors: true
+      backoff:
+        initial-interval: 2000ms
+        max-interval: 30000ms
+        multiplier: 2
+
+    # GigaChat config
+    gigachat:
+      auth:
+        bearer:
+          api-key: ${GIGACHAT_API_KEY}
+        scope: ${GIGACHAT_API_SCOPE:GIGACHAT_API_PERS}
+        unsafe-ssl: true
+      chat:
+        options:
+          model: GigaChat-2-Max
+          temperature: 0.0
+          max-tokens: 2000
+      embedding:
+        options:
+          model: EmbeddingsGigaR
+
+    # RAGAS auto-detects GigaChat beans
+    ragas:
+      providers:
+        auto-detect-beans: true
+        default-provider:
+          enabled: false
+        default-options:
+          temperature: 0.0
+          max-tokens: 2000
+      allure:
+        enabled: true
+        language: ru
+
+logging:
+  level:
+    ai.qa.solutions: DEBUG
+    chat.giga: INFO
+    org.springframework.ai: WARN


### PR DESCRIPTION
## Summary

Add a standalone runnable GigaChat demo under `examples/gigachat-demo/` that mirrors README.ru.md pipelines and validates the published `0.3.2` artifacts end-to-end against real GigaChat-2-Max.

**Not a reactor module** — not in `<modules>`, not built by CI, will not affect release builds. Parent is Spring Boot 3.5.13 directly; RAGAS pulled from Maven Central (`0.3.2`).

## What's inside

- `pom.xml` — SB 3.5.13 parent, `spring-ai-ragas-spring-boot-starter:0.3.2` (starter alone — verifies #7 fix), `spring-ai-ragas-allure:0.3.2`, allure-junit5, aspectjweaver agent, allure-maven report plugin
- `application.yml` — GigaChat auth scope, `unsafe-ssl`, `GigaChat-2-Max`, `EmbeddingsGigaR`, `spring.ai.ragas.allure.enabled=true`, `language: ru`
- `AgentEvaluationWithReferencesTest` — Pipeline 1 with references (11 metric invocations: ToolCallAccuracy, AgentGoalAccuracy WITH_REFERENCE, 5× atomic AspectCritic, SimpleCriteriaScore, TopicAdherence, ContextRecall, 5-level RubricsScore)
- `ProductionSamplingTest` — Pipeline 2 without references (9 metric invocations)
- Criteria follow best-practice rules: atomic facts, single-signal rubric progression, quantified references

## Running locally

```bash
export GIGACHAT_API_KEY=...
export GIGACHAT_API_SCOPE=GIGACHAT_API_PERS
mvn -f examples/gigachat-demo/pom.xml test
mvn -f examples/gigachat-demo/pom.xml io.qameta.allure:allure-maven:2.15.2:serve
```

## Test plan
- [x] Parent reactor `mvn -N validate` — no change (examples invisible)
- [x] `mvn -f examples/gigachat-demo/pom.xml test-compile` — green
- [x] Previously verified against real GigaChat-2-Max: both tests pass, 46 allure-results files, per-metric steps with attachments
- [x] CI `Maven Build` on main stays green (examples not in reactor)
