### PR TITLE
feat(allure): builder API with step/attachment/section toggles

### DIFF
--- a/spring-ai-ragas-allure/src/main/java/ai/qa/solutions/allure/config/AllureRagasAutoconfiguration.java
+++ b/spring-ai-ragas-allure/src/main/java/ai/qa/solutions/allure/config/AllureRagasAutoconfiguration.java
@@ -106,6 +106,11 @@ public class AllureRagasAutoconfiguration {
                 properties.getLanguage(),
                 properties.isIncludePrompts(),
                 properties.isIncludeResponses());
-        return new AllureMetricExecutionListener(properties, templateEngine, attachmentWriter, methodologyLoader);
+        return AllureMetricExecutionListener.builder()
+                .properties(properties)
+                .templateEngine(templateEngine)
+                .attachmentWriter(attachmentWriter)
+                .methodologyLoader(methodologyLoader)
+                .build();
     }
 }

--- a/spring-ai-ragas-allure/src/main/java/ai/qa/solutions/allure/listener/AllureAttachmentWriter.java
+++ b/spring-ai-ragas-allure/src/main/java/ai/qa/solutions/allure/listener/AllureAttachmentWriter.java
@@ -38,7 +38,7 @@ public class AllureAttachmentWriter {
     }
 
     /**
-     * Writes an HTML attachment for the evaluation report.
+     * Writes an HTML attachment for the evaluation report using {@link RenderConfig#defaults()}.
      *
      * @param data the evaluation report data
      */
@@ -54,7 +54,24 @@ public class AllureAttachmentWriter {
     }
 
     /**
-     * Writes a Markdown attachment for the evaluation report.
+     * Writes an HTML attachment for the evaluation report with the given render configuration.
+     *
+     * @param data the evaluation report data
+     * @param renderConfig the render configuration controlling which sections to emit
+     */
+    public void writeHtmlAttachment(final EvaluationReportData data, final RenderConfig renderConfig) {
+        try {
+            final String html = templateEngine.renderHtml(data, renderConfig);
+            final String name = buildAttachmentName(data, "Report");
+            lifecycle.addAttachment(name, HTML_CONTENT_TYPE, HTML_EXTENSION, html.getBytes(StandardCharsets.UTF_8));
+            log.debug("Added HTML attachment '{}' for metric '{}'", name, data.getMetricName());
+        } catch (final Exception e) {
+            log.error("Failed to write HTML attachment for metric '{}'", data.getMetricName(), e);
+        }
+    }
+
+    /**
+     * Writes a Markdown attachment for the evaluation report using {@link RenderConfig#defaults()}.
      *
      * @param data the evaluation report data
      */
@@ -71,7 +88,26 @@ public class AllureAttachmentWriter {
     }
 
     /**
-     * Writes an HTML attachment for the evaluation report to a specific step by UUID.
+     * Writes a Markdown attachment for the evaluation report with the given render configuration.
+     *
+     * @param data the evaluation report data
+     * @param renderConfig the render configuration controlling which sections to emit
+     */
+    public void writeMarkdownAttachment(final EvaluationReportData data, final RenderConfig renderConfig) {
+        try {
+            final String markdown = templateEngine.renderMarkdown(data, renderConfig);
+            final String name = buildAttachmentName(data, "MD");
+            lifecycle.addAttachment(
+                    name, MARKDOWN_CONTENT_TYPE, MARKDOWN_EXTENSION, markdown.getBytes(StandardCharsets.UTF_8));
+            log.debug("Added Markdown attachment '{}' for metric '{}'", name, data.getMetricName());
+        } catch (final Exception e) {
+            log.error("Failed to write Markdown attachment for metric '{}'", data.getMetricName(), e);
+        }
+    }
+
+    /**
+     * Writes an HTML attachment for the evaluation report to a specific step by UUID using
+     * {@link RenderConfig#defaults()}.
      * <p>
      * This method bypasses ThreadLocal context and directly attaches to the specified step,
      * making it safe to use from async threads.
@@ -92,7 +128,32 @@ public class AllureAttachmentWriter {
     }
 
     /**
-     * Writes a Markdown attachment for the evaluation report to a specific step by UUID.
+     * Writes an HTML attachment for the evaluation report to a specific step by UUID with the
+     * given render configuration.
+     * <p>
+     * This method bypasses ThreadLocal context and directly attaches to the specified step,
+     * making it safe to use from async threads.
+     *
+     * @param stepUuid the UUID of the step to attach to
+     * @param data the evaluation report data
+     * @param renderConfig the render configuration controlling which sections to emit
+     */
+    public void writeHtmlAttachmentToStep(
+            final String stepUuid, final EvaluationReportData data, final RenderConfig renderConfig) {
+        try {
+            final String html = templateEngine.renderHtml(data, renderConfig);
+            final String name = buildAttachmentName(data, "Report");
+            addAttachmentToStep(
+                    stepUuid, name, HTML_CONTENT_TYPE, HTML_EXTENSION, html.getBytes(StandardCharsets.UTF_8));
+            log.debug("Added HTML attachment '{}' to step '{}' for metric '{}'", name, stepUuid, data.getMetricName());
+        } catch (final Exception e) {
+            log.error("Failed to write HTML attachment for metric '{}'", data.getMetricName(), e);
+        }
+    }
+
+    /**
+     * Writes a Markdown attachment for the evaluation report to a specific step by UUID using
+     * {@link RenderConfig#defaults()}.
      * <p>
      * This method bypasses ThreadLocal context and directly attaches to the specified step,
      * making it safe to use from async threads.
@@ -103,6 +164,38 @@ public class AllureAttachmentWriter {
     public void writeMarkdownAttachmentToStep(final String stepUuid, final EvaluationReportData data) {
         try {
             final String markdown = templateEngine.renderMarkdown(data);
+            final String name = buildAttachmentName(data, "MD");
+            addAttachmentToStep(
+                    stepUuid,
+                    name,
+                    MARKDOWN_CONTENT_TYPE,
+                    MARKDOWN_EXTENSION,
+                    markdown.getBytes(StandardCharsets.UTF_8));
+            log.debug(
+                    "Added Markdown attachment '{}' to step '{}' for metric '{}'",
+                    name,
+                    stepUuid,
+                    data.getMetricName());
+        } catch (final Exception e) {
+            log.error("Failed to write Markdown attachment for metric '{}'", data.getMetricName(), e);
+        }
+    }
+
+    /**
+     * Writes a Markdown attachment for the evaluation report to a specific step by UUID with the
+     * given render configuration.
+     * <p>
+     * This method bypasses ThreadLocal context and directly attaches to the specified step,
+     * making it safe to use from async threads.
+     *
+     * @param stepUuid the UUID of the step to attach to
+     * @param data the evaluation report data
+     * @param renderConfig the render configuration controlling which sections to emit
+     */
+    public void writeMarkdownAttachmentToStep(
+            final String stepUuid, final EvaluationReportData data, final RenderConfig renderConfig) {
+        try {
+            final String markdown = templateEngine.renderMarkdown(data, renderConfig);
             final String name = buildAttachmentName(data, "MD");
             addAttachmentToStep(
                     stepUuid,

--- a/spring-ai-ragas-allure/src/main/java/ai/qa/solutions/allure/listener/AllureMetricExecutionListener.java
+++ b/spring-ai-ragas-allure/src/main/java/ai/qa/solutions/allure/listener/AllureMetricExecutionListener.java
@@ -45,10 +45,65 @@ import lombok.extern.slf4j.Slf4j;
  * // Automatic (via Spring Boot autoconfiguration)
  * spring.ai.ragas.allure.enabled=true
  *
- * // Manual
- * AllureMetricExecutionListener listener = new AllureMetricExecutionListener(...);
+ * // Manual via builder (recommended)
+ * AllureMetricExecutionListener listener = AllureMetricExecutionListener.builder()
+ *         .properties(properties)
+ *         .templateEngine(templateEngine)
+ *         .attachmentWriter(attachmentWriter)
+ *         .methodologyLoader(methodologyLoader)
+ *         .withStep(false)                  // optional, default true
+ *         .withHtmlAttachment(true)         // optional, default true
+ *         .withMarkdownAttachment(false)    // optional, default true
+ *         .withSummary(true)                // optional, default true
+ *         .withExplanation(true)            // optional, default true
+ *         .withMethodology(true)            // optional, default FALSE (see migration note below)
+ *         .withExecutionLog(true)           // optional, default true
+ *         .withExcludedModels(true)         // optional, default true
+ *         .build();
  * metric.addListener(listener);
  * }</pre>
+ *
+ * <h3>{@code withStep} flag</h3>
+ * <p>
+ * Controls whether the listener wraps each metric evaluation in its own Allure
+ * step (named after the metric). Default is {@code true}.
+ * <ul>
+ *   <li>{@code withStep=true} (default): the listener calls
+ *       {@link AllureLifecycle#startStep(String, String, StepResult) startStep} /
+ *       {@link AllureLifecycle#stopStep(String) stopStep} around the HTML/Markdown
+ *       attachments. If no Allure parent context is found, the listener falls back
+ *       to {@link io.qameta.allure.Allure}'s ThreadLocal-based attachment methods.</li>
+ *   <li>{@code withStep=false}: the listener skips {@code startStep}/{@code stopStep}
+ *       and writes attachments directly to the captured parent UUID. If no Allure
+ *       parent context is found, the listener logs a warning and skips the
+ *       attachments entirely (no ThreadLocal fallback).</li>
+ * </ul>
+ * Use {@code withStep=false} when the host test framework already wraps each
+ * metric call in its own outer Allure step and the inner step from this listener
+ * would be a redundant nesting level.
+ *
+ * <h3>Attachment and section toggles</h3>
+ * <p>
+ * The builder exposes seven additional flags that control which attachments are
+ * written and which sections appear inside each rendered report. Two of them
+ * gate the Allure attachments themselves ({@code withHtmlAttachment},
+ * {@code withMarkdownAttachment}); the other five toggle individual sections
+ * within the HTML and Markdown templates ({@code withSummary},
+ * {@code withExplanation}, {@code withMethodology}, {@code withExecutionLog},
+ * {@code withExcludedModels}). All defaults are {@code true} <b>except
+ * {@code withMethodology}, which defaults to {@code false}</b>.
+ * <p>
+ * If both attachment toggles are {@code false}, no Allure step is created even
+ * when {@code withStep=true} (the listener performs an early return).
+ *
+ * <h3>Breaking change: methodology section default</h3>
+ * <p>
+ * Earlier versions of this listener always rendered the methodology section in
+ * both attachments. Starting with the {@link RenderConfig}-aware build, the
+ * methodology section is omitted by default to keep attachments compact.
+ * <p>
+ * Migration: callers that need the methodology section must opt in explicitly
+ * via {@code .withMethodology(true)} on the builder.
  */
 @Slf4j
 public class AllureMetricExecutionListener implements MetricExecutionListener {
@@ -59,6 +114,8 @@ public class AllureMetricExecutionListener implements MetricExecutionListener {
     private final MethodologyLoader methodologyLoader;
     private final ScoreExplanationFactory explanationFactory;
     private final AllureLifecycle lifecycle;
+    private final boolean withStep;
+    private final RenderConfig renderConfig;
 
     // Mutable state (reset per evaluation via forEvaluation())
     private MetricEvaluationContext evaluationContext;
@@ -75,17 +132,22 @@ public class AllureMetricExecutionListener implements MetricExecutionListener {
      * @param templateEngine the Freemarker template engine
      * @param attachmentWriter the Allure attachment writer
      * @param methodologyLoader the methodology documentation loader
+     * @deprecated since 0.4.0. Use {@link #builder()} instead. This constructor is retained
+     *     for backward compatibility and delegates to the builder defaults
+     *     ({@code lifecycle = Allure.getLifecycle()}, {@code withStep = true}).
      */
+    @Deprecated(since = "0.4.0", forRemoval = false)
     public AllureMetricExecutionListener(
             final AllureRagasProperties properties,
             final FreemarkerTemplateEngine templateEngine,
             final AllureAttachmentWriter attachmentWriter,
             final MethodologyLoader methodologyLoader) {
-        this(properties, templateEngine, attachmentWriter, methodologyLoader, Allure.getLifecycle());
+        this(properties, templateEngine, attachmentWriter, methodologyLoader, Allure.getLifecycle(), true);
     }
 
     /**
      * Creates an AllureMetricExecutionListener with explicit lifecycle (for testing).
+     * Delegates to the 6-arg constructor with {@code withStep = true} (default behaviour).
      *
      * @param properties the configuration properties
      * @param templateEngine the Freemarker template engine
@@ -99,12 +161,78 @@ public class AllureMetricExecutionListener implements MetricExecutionListener {
             final AllureAttachmentWriter attachmentWriter,
             final MethodologyLoader methodologyLoader,
             final AllureLifecycle lifecycle) {
+        this(properties, templateEngine, attachmentWriter, methodologyLoader, lifecycle, true);
+    }
+
+    /**
+     * Creates an AllureMetricExecutionListener with explicit lifecycle and step toggle.
+     * Package-private — production code should use {@link #builder()}.
+     * Delegates to the 7-arg constructor with {@link RenderConfig#defaults()}.
+     *
+     * @param properties the configuration properties
+     * @param templateEngine the Freemarker template engine
+     * @param attachmentWriter the Allure attachment writer
+     * @param methodologyLoader the methodology documentation loader
+     * @param lifecycle the Allure lifecycle instance
+     * @param withStep whether to wrap metric evaluation in an Allure step (see class javadoc
+     *     for the no-parent-context asymmetry between {@code withStep=true} and {@code false})
+     */
+    AllureMetricExecutionListener(
+            final AllureRagasProperties properties,
+            final FreemarkerTemplateEngine templateEngine,
+            final AllureAttachmentWriter attachmentWriter,
+            final MethodologyLoader methodologyLoader,
+            final AllureLifecycle lifecycle,
+            final boolean withStep) {
+        this(
+                properties,
+                templateEngine,
+                attachmentWriter,
+                methodologyLoader,
+                lifecycle,
+                withStep,
+                RenderConfig.defaults());
+    }
+
+    /**
+     * Creates an AllureMetricExecutionListener with explicit lifecycle, step toggle, and
+     * render configuration. Package-private — production code should use {@link #builder()}.
+     *
+     * @param properties the configuration properties
+     * @param templateEngine the Freemarker template engine
+     * @param attachmentWriter the Allure attachment writer
+     * @param methodologyLoader the methodology documentation loader
+     * @param lifecycle the Allure lifecycle instance
+     * @param withStep whether to wrap metric evaluation in an Allure step (see class javadoc
+     *     for the no-parent-context asymmetry between {@code withStep=true} and {@code false})
+     * @param renderConfig the attachment/section render configuration (see {@link RenderConfig})
+     */
+    AllureMetricExecutionListener(
+            final AllureRagasProperties properties,
+            final FreemarkerTemplateEngine templateEngine,
+            final AllureAttachmentWriter attachmentWriter,
+            final MethodologyLoader methodologyLoader,
+            final AllureLifecycle lifecycle,
+            final boolean withStep,
+            final RenderConfig renderConfig) {
         this.properties = properties;
         this.templateEngine = templateEngine;
         this.attachmentWriter = attachmentWriter;
         this.methodologyLoader = methodologyLoader;
         this.explanationFactory = new ScoreExplanationFactory();
         this.lifecycle = lifecycle;
+        this.withStep = withStep;
+        this.renderConfig = renderConfig;
+    }
+
+    /**
+     * Creates a new {@link Builder} for configuring an {@code AllureMetricExecutionListener}.
+     *
+     * @return a fresh builder instance with default {@code lifecycle = Allure.getLifecycle()}
+     *     and {@code withStep = true}
+     */
+    public static Builder builder() {
+        return new Builder();
     }
 
     @Override
@@ -116,7 +244,10 @@ public class AllureMetricExecutionListener implements MetricExecutionListener {
         // Do NOT call startStep here — it would push to main thread's ThreadLocal
         // and stopStep would remove from storage, breaking UUID-based operations
         this.parentUuid = lifecycle.getCurrentTestCaseOrStep().orElse(null);
-        this.metricStepUuid = UUID.randomUUID().toString();
+        // metricStepUuid is only relevant when withStep=true; leave null otherwise so the
+        // catch-block cleanup (lifecycle.updateStep / stopStep) naturally no-ops via the
+        // existing `if (metricStepUuid != null)` guard.
+        this.metricStepUuid = withStep ? UUID.randomUUID().toString() : null;
 
         if (parentUuid == null) {
             log.warn(
@@ -133,34 +264,78 @@ public class AllureMetricExecutionListener implements MetricExecutionListener {
 
     @Override
     public void afterMetricEvaluation(final MetricEvaluationResult result) {
+        if (!renderConfig.anyAttachmentEnabled()) {
+            log.warn(
+                    "Allure listener: both HTML and Markdown attachments disabled for metric '{}', skipping",
+                    result.getMetricName());
+            return;
+        }
+        if (!renderConfig.anySectionEnabled()) {
+            log.warn(
+                    "Allure listener: all report sections disabled for metric '{}', skipping attachments",
+                    result.getMetricName());
+            return;
+        }
         try {
-            final EvaluationReportData reportData = buildReportData(result);
+            if (withStep) {
+                final EvaluationReportData reportData = buildReportData(result);
 
-            if (parentUuid != null && metricStepUuid != null) {
-                // Create Allure step on THIS thread (async) — avoids main thread ThreadLocal corruption
-                final Status status = result.getAggregatedScore() != null ? Status.PASSED : Status.BROKEN;
-                final StepResult stepResult =
-                        new StepResult().setName(result.getMetricName()).setStatus(status);
-                lifecycle.startStep(parentUuid, metricStepUuid, stepResult);
+                if (parentUuid != null && metricStepUuid != null) {
+                    // Create Allure step on THIS thread (async) — avoids main thread ThreadLocal corruption
+                    final Status status = result.getAggregatedScore() != null ? Status.PASSED : Status.BROKEN;
+                    final StepResult stepResult =
+                            new StepResult().setName(result.getMetricName()).setStatus(status);
+                    lifecycle.startStep(parentUuid, metricStepUuid, stepResult);
 
-                // Write attachments — step is in storage, UUID-based methods work
-                attachmentWriter.writeHtmlAttachmentToStep(metricStepUuid, reportData);
-                attachmentWriter.writeMarkdownAttachmentToStep(metricStepUuid, reportData);
+                    // Write attachments — step is in storage, UUID-based methods work
+                    if (renderConfig.htmlAttachment()) {
+                        attachmentWriter.writeHtmlAttachmentToStep(metricStepUuid, reportData, renderConfig);
+                    }
+                    if (renderConfig.markdownAttachment()) {
+                        attachmentWriter.writeMarkdownAttachmentToStep(metricStepUuid, reportData, renderConfig);
+                    }
 
-                // Finalize step — sets stop time, removes from storage, pops from THIS thread's ThreadLocal
-                lifecycle.stopStep(metricStepUuid);
+                    // Finalize step — sets stop time, removes from storage, pops from THIS thread's ThreadLocal
+                    lifecycle.stopStep(metricStepUuid);
 
-                log.debug(
-                        "Allure listener: Created step '{}' with attachments for metric '{}', score {}",
-                        metricStepUuid,
-                        result.getMetricName(),
-                        result.getAggregatedScore());
+                    log.debug(
+                            "Allure listener: Created step '{}' with attachments for metric '{}', score {}",
+                            metricStepUuid,
+                            result.getMetricName(),
+                            result.getAggregatedScore());
+                } else {
+                    // Fallback to ThreadLocal-based methods
+                    if (renderConfig.htmlAttachment()) {
+                        attachmentWriter.writeHtmlAttachment(reportData, renderConfig);
+                    }
+                    if (renderConfig.markdownAttachment()) {
+                        attachmentWriter.writeMarkdownAttachment(reportData, renderConfig);
+                    }
+                    log.debug(
+                            "Allure listener: Generated attachments for metric '{}' with score {} (no parent context)",
+                            result.getMetricName(),
+                            result.getAggregatedScore());
+                }
             } else {
-                // Fallback to ThreadLocal-based methods
-                attachmentWriter.writeHtmlAttachment(reportData);
-                attachmentWriter.writeMarkdownAttachment(reportData);
+                // withStep == false — write attachments directly to parent UUID without wrapping step
+                if (parentUuid == null) {
+                    log.warn(
+                            "Allure listener: withStep=false but no parent context for metric '{}', skipping attachments",
+                            result.getMetricName());
+                    return;
+                }
+
+                final EvaluationReportData reportData = buildReportData(result);
+                if (renderConfig.htmlAttachment()) {
+                    attachmentWriter.writeHtmlAttachmentToStep(parentUuid, reportData, renderConfig);
+                }
+                if (renderConfig.markdownAttachment()) {
+                    attachmentWriter.writeMarkdownAttachmentToStep(parentUuid, reportData, renderConfig);
+                }
+
                 log.debug(
-                        "Allure listener: Generated attachments for metric '{}' with score {} (no parent context)",
+                        "Allure listener: Attached HTML/Markdown reports directly to parent '{}' for metric '{}', score {} (withStep=false)",
+                        parentUuid,
                         result.getMetricName(),
                         result.getAggregatedScore());
             }
@@ -181,7 +356,7 @@ public class AllureMetricExecutionListener implements MetricExecutionListener {
     public MetricExecutionListener forEvaluation() {
         // CRITICAL: Return new instance for thread safety
         return new AllureMetricExecutionListener(
-                properties, templateEngine, attachmentWriter, methodologyLoader, lifecycle);
+                properties, templateEngine, attachmentWriter, methodologyLoader, lifecycle, withStep, renderConfig);
     }
 
     @Override
@@ -411,5 +586,236 @@ public class AllureMetricExecutionListener implements MetricExecutionListener {
         }
 
         return entries;
+    }
+
+    /**
+     * Fluent builder for {@link AllureMetricExecutionListener}.
+     * <p>
+     * Required fields: {@code properties}, {@code templateEngine},
+     * {@code attachmentWriter}, {@code methodologyLoader}.
+     * <p>
+     * Optional fields: {@code lifecycle} (default {@link Allure#getLifecycle()}),
+     * {@code withStep} (default {@code true}). See class-level javadoc on
+     * {@link AllureMetricExecutionListener} for the no-parent-context asymmetry
+     * between {@code withStep=true} and {@code withStep=false}.
+     */
+    public static class Builder {
+        private AllureRagasProperties properties;
+        private FreemarkerTemplateEngine templateEngine;
+        private AllureAttachmentWriter attachmentWriter;
+        private MethodologyLoader methodologyLoader;
+        private AllureLifecycle lifecycle = Allure.getLifecycle();
+        private boolean withStep = true;
+
+        private boolean withHtmlAttachment = true;
+        private boolean withMarkdownAttachment = true;
+        private boolean withSummary = true;
+        private boolean withExplanation = true;
+        private boolean withMethodology = false;
+        private boolean withExecutionLog = true;
+        private boolean withExcludedModels = true;
+
+        /**
+         * Sets the Ragas Allure configuration properties (required).
+         *
+         * @param properties the configuration properties
+         * @return this builder
+         */
+        public Builder properties(final AllureRagasProperties properties) {
+            this.properties = properties;
+            return this;
+        }
+
+        /**
+         * Sets the Freemarker template engine (required).
+         *
+         * @param templateEngine the template engine
+         * @return this builder
+         */
+        public Builder templateEngine(final FreemarkerTemplateEngine templateEngine) {
+            this.templateEngine = templateEngine;
+            return this;
+        }
+
+        /**
+         * Sets the Allure attachment writer (required).
+         *
+         * @param attachmentWriter the attachment writer
+         * @return this builder
+         */
+        public Builder attachmentWriter(final AllureAttachmentWriter attachmentWriter) {
+            this.attachmentWriter = attachmentWriter;
+            return this;
+        }
+
+        /**
+         * Sets the methodology documentation loader (required).
+         *
+         * @param methodologyLoader the methodology loader
+         * @return this builder
+         */
+        public Builder methodologyLoader(final MethodologyLoader methodologyLoader) {
+            this.methodologyLoader = methodologyLoader;
+            return this;
+        }
+
+        /**
+         * Sets the Allure lifecycle (optional, default {@link Allure#getLifecycle()}).
+         *
+         * @param lifecycle the lifecycle instance
+         * @return this builder
+         */
+        public Builder lifecycle(final AllureLifecycle lifecycle) {
+            this.lifecycle = lifecycle;
+            return this;
+        }
+
+        /**
+         * Sets whether the listener wraps each metric evaluation in its own Allure step
+         * (optional, default {@code true}).
+         * <p>
+         * When {@code true} (default), the listener calls
+         * {@link AllureLifecycle#startStep(String, String, StepResult) startStep} /
+         * {@link AllureLifecycle#stopStep(String) stopStep} around the HTML/Markdown
+         * attachments. If no Allure parent context is found, the listener falls back
+         * to {@link Allure}'s ThreadLocal-based attachment methods.
+         * <p>
+         * When {@code false}, the listener writes attachments directly to the captured
+         * parent UUID and skips {@code startStep}/{@code stopStep}. If no Allure parent
+         * context is found, the listener logs a warning and skips the attachments
+         * entirely (no ThreadLocal fallback). Use this when the host test framework
+         * already wraps each metric call in its own outer Allure step.
+         *
+         * @param withStep whether to wrap evaluation in an Allure step
+         * @return this builder
+         */
+        public Builder withStep(final boolean withStep) {
+            this.withStep = withStep;
+            return this;
+        }
+
+        /**
+         * Sets whether the rendered HTML report should be attached to the Allure step
+         * (optional, default {@code true}).
+         * <p>
+         * If both this flag and {@link #withMarkdownAttachment(boolean)} are disabled,
+         * no Allure step is created even when {@code withStep=true} (the listener
+         * performs an early return in {@code afterMetricEvaluation}).
+         *
+         * @param withHtmlAttachment whether to attach the HTML report
+         * @return this builder
+         */
+        public Builder withHtmlAttachment(final boolean withHtmlAttachment) {
+            this.withHtmlAttachment = withHtmlAttachment;
+            return this;
+        }
+
+        /**
+         * Sets whether the rendered Markdown report should be attached to the Allure
+         * step (optional, default {@code true}).
+         * <p>
+         * If both this flag and {@link #withHtmlAttachment(boolean)} are disabled,
+         * no Allure step is created even when {@code withStep=true} (the listener
+         * performs an early return in {@code afterMetricEvaluation}).
+         *
+         * @param withMarkdownAttachment whether to attach the Markdown report
+         * @return this builder
+         */
+        public Builder withMarkdownAttachment(final boolean withMarkdownAttachment) {
+            this.withMarkdownAttachment = withMarkdownAttachment;
+            return this;
+        }
+
+        /**
+         * Sets whether the summary section (scores, timing, models) is rendered in
+         * both attachments (optional, default {@code true}).
+         *
+         * @param withSummary whether to render the summary section
+         * @return this builder
+         */
+        public Builder withSummary(final boolean withSummary) {
+            this.withSummary = withSummary;
+            return this;
+        }
+
+        /**
+         * Sets whether the per-step / per-model explanation section is rendered in
+         * both attachments (optional, default {@code true}).
+         *
+         * @param withExplanation whether to render the explanation section
+         * @return this builder
+         */
+        public Builder withExplanation(final boolean withExplanation) {
+            this.withExplanation = withExplanation;
+            return this;
+        }
+
+        /**
+         * Sets whether the methodology section is rendered in both attachments
+         * (optional, default <b>{@code false}</b>).
+         * <p>
+         * <b>Breaking change:</b> earlier listener versions always rendered the
+         * methodology section. The default has been flipped to {@code false} to keep
+         * attachments compact.
+         * <p>
+         * Migration: callers that need the previous behavior must call
+         * {@code .withMethodology(true)} explicitly when configuring the builder.
+         *
+         * @param withMethodology whether to render the methodology section
+         * @return this builder
+         */
+        public Builder withMethodology(final boolean withMethodology) {
+            this.withMethodology = withMethodology;
+            return this;
+        }
+
+        /**
+         * Sets whether the execution log / steps timeline section is rendered in
+         * both attachments (optional, default {@code true}).
+         *
+         * @param withExecutionLog whether to render the execution log section
+         * @return this builder
+         */
+        public Builder withExecutionLog(final boolean withExecutionLog) {
+            this.withExecutionLog = withExecutionLog;
+            return this;
+        }
+
+        /**
+         * Sets whether the excluded models section is rendered in both attachments
+         * (optional, default {@code true}).
+         *
+         * @param withExcludedModels whether to render the excluded models section
+         * @return this builder
+         */
+        public Builder withExcludedModels(final boolean withExcludedModels) {
+            this.withExcludedModels = withExcludedModels;
+            return this;
+        }
+
+        /**
+         * Builds the {@link AllureMetricExecutionListener} instance.
+         *
+         * @return a new listener configured with the values set on this builder
+         * @throws NullPointerException if any required field ({@code properties},
+         *     {@code templateEngine}, {@code attachmentWriter}, {@code methodologyLoader})
+         *     is {@code null}. The exception message contains the missing field name.
+         */
+        public AllureMetricExecutionListener build() {
+            java.util.Objects.requireNonNull(properties, "properties must not be null");
+            java.util.Objects.requireNonNull(templateEngine, "templateEngine must not be null");
+            java.util.Objects.requireNonNull(attachmentWriter, "attachmentWriter must not be null");
+            java.util.Objects.requireNonNull(methodologyLoader, "methodologyLoader must not be null");
+            final RenderConfig renderConfig = new RenderConfig(
+                    withHtmlAttachment,
+                    withMarkdownAttachment,
+                    withSummary,
+                    withExplanation,
+                    withMethodology,
+                    withExecutionLog,
+                    withExcludedModels);
+            return new AllureMetricExecutionListener(
+                    properties, templateEngine, attachmentWriter, methodologyLoader, lifecycle, withStep, renderConfig);
+        }
     }
 }

--- a/spring-ai-ragas-allure/src/main/java/ai/qa/solutions/allure/listener/RenderConfig.java
+++ b/spring-ai-ragas-allure/src/main/java/ai/qa/solutions/allure/listener/RenderConfig.java
@@ -1,0 +1,60 @@
+package ai.qa.solutions.allure.listener;
+
+/**
+ * Configuration for selectively rendering report sections and attachments.
+ * <p>
+ * Used by {@link ai.qa.solutions.allure.template.FreemarkerTemplateEngine} and
+ * {@link AllureAttachmentWriter} to toggle individual report parts on or off.
+ * Templates read this record from the Freemarker data model under the key
+ * {@code "renderConfig"} to decide which sections to emit.
+ * <p>
+ * <b>Breaking change vs. prior behavior:</b> {@link #methodology()} defaults to
+ * {@code false} in {@link #defaults()}. Earlier listener implementations always
+ * included the methodology block; consumers that relied on that behavior must
+ * opt in explicitly via the builder.
+ *
+ * @param htmlAttachment     whether to attach the rendered HTML report to the step
+ * @param markdownAttachment whether to attach the rendered Markdown report to the step
+ * @param summary            whether to render the high-level summary section (scores,
+ *                           timing, models)
+ * @param explanation        whether to render the per-step / per-model explanation section
+ * @param methodology        whether to render the metric methodology section. Defaults to
+ *                           {@code false} (breaking change) to keep attachments compact —
+ *                           opt in only when methodology context is needed
+ * @param executionLog       whether to render the execution log / steps timeline section
+ * @param excludedModels     whether to render the excluded models section (models filtered
+ *                           out of aggregation due to errors or policy)
+ */
+public record RenderConfig(
+        boolean htmlAttachment,
+        boolean markdownAttachment,
+        boolean summary,
+        boolean explanation,
+        boolean methodology,
+        boolean executionLog,
+        boolean excludedModels) {
+
+    /**
+     * Returns the default configuration: all attachments and sections enabled
+     * <i>except</i> {@link #methodology()}, which defaults to {@code false}.
+     *
+     * @return default {@code RenderConfig}
+     */
+    public static RenderConfig defaults() {
+        return new RenderConfig(true, true, true, true, false, true, true);
+    }
+
+    /**
+     * @return {@code true} if at least one attachment format (HTML or Markdown) is enabled
+     */
+    public boolean anyAttachmentEnabled() {
+        return htmlAttachment || markdownAttachment;
+    }
+
+    /**
+     * @return {@code true} if at least one report section is enabled
+     */
+    public boolean anySectionEnabled() {
+        return summary || explanation || methodology || executionLog || excludedModels;
+    }
+}

--- a/spring-ai-ragas-allure/src/main/java/ai/qa/solutions/allure/template/FreemarkerTemplateEngine.java
+++ b/spring-ai-ragas-allure/src/main/java/ai/qa/solutions/allure/template/FreemarkerTemplateEngine.java
@@ -1,6 +1,7 @@
 package ai.qa.solutions.allure.template;
 
 import ai.qa.solutions.allure.i18n.ReportMessages;
+import ai.qa.solutions.allure.listener.RenderConfig;
 import ai.qa.solutions.allure.model.EvaluationReportData;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
@@ -35,29 +36,59 @@ public class FreemarkerTemplateEngine {
     }
 
     /**
-     * Renders the HTML report for the given evaluation data.
+     * Renders the HTML report for the given evaluation data using {@link RenderConfig#defaults()}.
      *
      * @param data the evaluation report data
      * @return rendered HTML content
      * @throws TemplateRenderException if rendering fails
      */
     public String renderHtml(final EvaluationReportData data) {
-        return render(HTML_TEMPLATE, data);
+        return renderHtml(data, RenderConfig.defaults());
     }
 
     /**
-     * Renders the Markdown report for the given evaluation data.
+     * Renders the HTML report for the given evaluation data and render configuration.
+     * <p>
+     * The provided {@code renderConfig} is exposed to the template under the key
+     * {@code "renderConfig"} so templates can selectively emit sections.
+     *
+     * @param data the evaluation report data
+     * @param renderConfig the render configuration controlling which sections to emit
+     * @return rendered HTML content
+     * @throws TemplateRenderException if rendering fails
+     */
+    public String renderHtml(final EvaluationReportData data, final RenderConfig renderConfig) {
+        return render(HTML_TEMPLATE, data, renderConfig);
+    }
+
+    /**
+     * Renders the Markdown report for the given evaluation data using {@link RenderConfig#defaults()}.
      *
      * @param data the evaluation report data
      * @return rendered Markdown content
      * @throws TemplateRenderException if rendering fails
      */
     public String renderMarkdown(final EvaluationReportData data) {
-        return render(MARKDOWN_TEMPLATE, data);
+        return renderMarkdown(data, RenderConfig.defaults());
     }
 
     /**
-     * Renders a template with the given data.
+     * Renders the Markdown report for the given evaluation data and render configuration.
+     * <p>
+     * The provided {@code renderConfig} is exposed to the template under the key
+     * {@code "renderConfig"} so templates can selectively emit sections.
+     *
+     * @param data the evaluation report data
+     * @param renderConfig the render configuration controlling which sections to emit
+     * @return rendered Markdown content
+     * @throws TemplateRenderException if rendering fails
+     */
+    public String renderMarkdown(final EvaluationReportData data, final RenderConfig renderConfig) {
+        return render(MARKDOWN_TEMPLATE, data, renderConfig);
+    }
+
+    /**
+     * Renders a template with the given data using {@link RenderConfig#defaults()}.
      *
      * @param templateName the template file name
      * @param data the evaluation report data
@@ -65,9 +96,23 @@ public class FreemarkerTemplateEngine {
      * @throws TemplateRenderException if rendering fails
      */
     public String render(final String templateName, final EvaluationReportData data) {
+        return render(templateName, data, RenderConfig.defaults());
+    }
+
+    /**
+     * Renders a template with the given data and render configuration.
+     *
+     * @param templateName the template file name
+     * @param data the evaluation report data
+     * @param renderConfig the render configuration controlling which sections to emit
+     * @return rendered content
+     * @throws TemplateRenderException if rendering fails
+     */
+    public String render(final String templateName, final EvaluationReportData data, final RenderConfig renderConfig) {
         try {
             final Template template = configuration.getTemplate(templateName);
             final Map<String, Object> model = createTemplateModel(data);
+            model.put("renderConfig", renderConfig);
 
             try (final StringWriter writer = new StringWriter()) {
                 template.process(model, writer);

--- a/spring-ai-ragas-allure/src/main/resources/ai/qa/solutions/allure/templates/report-html.ftl
+++ b/spring-ai-ragas-allure/src/main/resources/ai/qa/solutions/allure/templates/report-html.ftl
@@ -1631,6 +1631,7 @@
         </header>
 
         <#-- Block 1: Summary (expanded by default) -->
+        <#if renderConfig.summary()>
         <section class="report-block" id="block-summary">
             <div class="block-header" onclick="toggleBlock('block-summary')">
                 <h2>${i18n["block.summary"]}</h2>
@@ -1640,8 +1641,10 @@
                 <#include "blocks/summary-block.ftl">
             </div>
         </section>
+        </#if>
 
         <#-- Block 2: Score Explanation (expanded by default if available) -->
+        <#if renderConfig.explanation()>
         <#if data.hasScoreExplanation()>
         <section class="report-block" id="block-explanation">
             <div class="block-header" onclick="toggleBlock('block-explanation')">
@@ -1653,8 +1656,10 @@
             </div>
         </section>
         </#if>
+        </#if>
 
         <#-- Block 3: Methodology (collapsed by default) -->
+        <#if renderConfig.methodology()>
         <section class="report-block collapsed" id="block-methodology">
             <div class="block-header" onclick="toggleBlock('block-methodology')">
                 <h2>${i18n["block.methodology"]}</h2>
@@ -1664,8 +1669,10 @@
                 <#include "blocks/methodology-block.ftl">
             </div>
         </section>
+        </#if>
 
         <#-- Block 3: Execution Log (collapsed by default) -->
+        <#if renderConfig.executionLog()>
         <section class="report-block collapsed" id="block-execution">
             <div class="block-header" onclick="toggleBlock('block-execution')">
                 <h2>${i18n["block.execution"]}</h2>
@@ -1675,6 +1682,7 @@
                 <#include "blocks/execution-log-block.ftl">
             </div>
         </section>
+        </#if>
     </div>
 
     <script>

--- a/spring-ai-ragas-allure/src/main/resources/ai/qa/solutions/allure/templates/report-markdown.ftl
+++ b/spring-ai-ragas-allure/src/main/resources/ai/qa/solutions/allure/templates/report-markdown.ftl
@@ -7,6 +7,7 @@
 
 ---
 
+<#if renderConfig.summary()>
 ## ${i18n["block.summary"]}
 
 ### ${i18n["summary.modelScores"]}
@@ -71,6 +72,8 @@ ${configJson}
 
 ---
 
+</#if>
+<#if renderConfig.explanation()>
 <#if data.hasScoreExplanation()>
 ## ${i18n["block.explanation"]}
 
@@ -138,12 +141,16 @@ ${step.inputData}
 ---
 
 </#if>
+</#if>
+<#if renderConfig.methodology()>
 ## ${i18n["block.methodology"]}
 
 ${methodologyMarkdown!'Methodology documentation not available.'}
 
 ---
 
+</#if>
+<#if renderConfig.executionLog()>
 ## ${i18n["block.execution"]}
 
 <#list steps as step>
@@ -193,6 +200,8 @@ ${modelResult.stackTrace}
 
 </#list>
 
+</#if>
+<#if renderConfig.excludedModels()>
 <#if exclusions?has_content>
 ---
 
@@ -215,4 +224,5 @@ ${excl.stackTrace}
 </details>
 </#if>
 </#list>
+</#if>
 </#if>

--- a/spring-ai-ragas-allure/src/test/java/ai/qa/solutions/allure/listener/AllureAttachmentWriterTest.java
+++ b/spring-ai-ragas-allure/src/test/java/ai/qa/solutions/allure/listener/AllureAttachmentWriterTest.java
@@ -99,6 +99,82 @@ class AllureAttachmentWriterTest {
         }
     }
 
+    @Nested
+    @DisplayName("RenderConfig overloads")
+    class RenderConfigOverloads {
+
+        @Test
+        @DisplayName("writeHtmlAttachmentToStep with RenderConfig should propagate config to template engine")
+        void writeHtmlAttachmentToStepWithRenderConfigShouldPropagateConfig() {
+            final EvaluationReportData data = createTestData(0.85);
+            final RenderConfig customConfig = new RenderConfig(true, true, true, true, true, true, true);
+            when(templateEngine.renderHtml(eq(data), eq(customConfig))).thenReturn("<html>cfg</html>");
+
+            writer.writeHtmlAttachmentToStep("step-uuid", data, customConfig);
+
+            verify(templateEngine).renderHtml(eq(data), eq(customConfig));
+        }
+
+        @Test
+        @DisplayName("writeMarkdownAttachmentToStep with RenderConfig should propagate config to template engine")
+        void writeMarkdownAttachmentToStepWithRenderConfigShouldPropagateConfig() {
+            final EvaluationReportData data = createTestData(0.85);
+            final RenderConfig customConfig = new RenderConfig(true, true, true, true, true, true, true);
+            when(templateEngine.renderMarkdown(eq(data), eq(customConfig))).thenReturn("# cfg");
+
+            writer.writeMarkdownAttachmentToStep("step-uuid", data, customConfig);
+
+            verify(templateEngine).renderMarkdown(eq(data), eq(customConfig));
+        }
+
+        @Test
+        @DisplayName("writeHtmlAttachment with RenderConfig should propagate config to template engine")
+        void writeHtmlAttachmentWithRenderConfigShouldPropagateConfig() {
+            final EvaluationReportData data = createTestData(0.85);
+            final RenderConfig customConfig = new RenderConfig(true, true, false, true, true, true, true);
+            when(templateEngine.renderHtml(eq(data), eq(customConfig))).thenReturn("<html>cfg</html>");
+
+            writer.writeHtmlAttachment(data, customConfig);
+
+            verify(templateEngine).renderHtml(eq(data), eq(customConfig));
+        }
+
+        @Test
+        @DisplayName("writeMarkdownAttachment with RenderConfig should propagate config to template engine")
+        void writeMarkdownAttachmentWithRenderConfigShouldPropagateConfig() {
+            final EvaluationReportData data = createTestData(0.85);
+            final RenderConfig customConfig = new RenderConfig(true, true, true, false, true, true, true);
+            when(templateEngine.renderMarkdown(eq(data), eq(customConfig))).thenReturn("# cfg");
+
+            writer.writeMarkdownAttachment(data, customConfig);
+
+            verify(templateEngine).renderMarkdown(eq(data), eq(customConfig));
+        }
+
+        @Test
+        @DisplayName("legacy 2-arg writeHtmlAttachmentToStep should call template engine without explicit RenderConfig")
+        void legacyTwoArgWriteHtmlAttachmentToStepShouldUseEngineDefaults() {
+            final EvaluationReportData data = createTestData(0.85);
+            when(templateEngine.renderHtml(eq(data))).thenReturn("<html>legacy</html>");
+
+            writer.writeHtmlAttachmentToStep("step-uuid", data);
+
+            verify(templateEngine).renderHtml(eq(data));
+        }
+
+        @Test
+        @DisplayName(
+                "legacy 2-arg writeMarkdownAttachmentToStep should call template engine without explicit RenderConfig")
+        void legacyTwoArgWriteMarkdownAttachmentToStepShouldUseEngineDefaults() {
+            final EvaluationReportData data = createTestData(0.85);
+            when(templateEngine.renderMarkdown(eq(data))).thenReturn("# legacy");
+
+            writer.writeMarkdownAttachmentToStep("step-uuid", data);
+
+            verify(templateEngine).renderMarkdown(eq(data));
+        }
+    }
+
     private EvaluationReportData createTestData(final Double score) {
         return EvaluationReportData.builder()
                 .metricName("TestMetric")

--- a/spring-ai-ragas-allure/src/test/java/ai/qa/solutions/allure/listener/AllureMetricExecutionListenerTest.java
+++ b/spring-ai-ragas-allure/src/test/java/ai/qa/solutions/allure/listener/AllureMetricExecutionListenerTest.java
@@ -1,6 +1,7 @@
 package ai.qa.solutions.allure.listener;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -14,6 +15,7 @@ import ai.qa.solutions.execution.ModelResult;
 import ai.qa.solutions.execution.listener.MetricExecutionListener;
 import ai.qa.solutions.execution.listener.dto.*;
 import ai.qa.solutions.sample.Sample;
+import io.qameta.allure.Allure;
 import io.qameta.allure.AllureLifecycle;
 import java.time.Duration;
 import java.util.ArrayDeque;
@@ -30,6 +32,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -149,8 +152,8 @@ class AllureMetricExecutionListenerTest {
             verify(lifecycle).stopStep(anyString());
 
             final ArgumentCaptor<EvaluationReportData> captor = ArgumentCaptor.forClass(EvaluationReportData.class);
-            verify(attachmentWriter).writeHtmlAttachmentToStep(anyString(), captor.capture());
-            verify(attachmentWriter).writeMarkdownAttachmentToStep(anyString(), any());
+            verify(attachmentWriter).writeHtmlAttachmentToStep(anyString(), captor.capture(), any(RenderConfig.class));
+            verify(attachmentWriter).writeMarkdownAttachmentToStep(anyString(), any(), any(RenderConfig.class));
 
             final EvaluationReportData reportData = captor.getValue();
             assertThat(reportData.getMetricName()).isEqualTo("Faithfulness");
@@ -193,7 +196,7 @@ class AllureMetricExecutionListenerTest {
             listener.afterMetricEvaluation(result);
 
             final ArgumentCaptor<EvaluationReportData> captor = ArgumentCaptor.forClass(EvaluationReportData.class);
-            verify(attachmentWriter).writeHtmlAttachmentToStep(anyString(), captor.capture());
+            verify(attachmentWriter).writeHtmlAttachmentToStep(anyString(), captor.capture(), any(RenderConfig.class));
 
             final EvaluationReportData reportData = captor.getValue();
             assertThat(reportData.getExclusions()).hasSize(1);
@@ -213,7 +216,7 @@ class AllureMetricExecutionListenerTest {
             when(methodologyLoader.loadMethodologyMarkdown(any())).thenReturn("# Methodology");
             doThrow(new RuntimeException("Write failed"))
                     .when(attachmentWriter)
-                    .writeHtmlAttachmentToStep(anyString(), any());
+                    .writeHtmlAttachmentToStep(anyString(), any(), any(RenderConfig.class));
 
             final Sample sample = Sample.builder().userInput("test").build();
             final MetricEvaluationContext context = MetricEvaluationContext.builder()
@@ -347,7 +350,8 @@ class AllureMetricExecutionListenerTest {
             // Verify: attachments generated for both metrics
             final ArgumentCaptor<EvaluationReportData> reportCaptor =
                     ArgumentCaptor.forClass(EvaluationReportData.class);
-            verify(attachmentWriter, times(2)).writeHtmlAttachmentToStep(anyString(), reportCaptor.capture());
+            verify(attachmentWriter, times(2))
+                    .writeHtmlAttachmentToStep(anyString(), reportCaptor.capture(), any(RenderConfig.class));
             assertThat(reportCaptor.getAllValues())
                     .extracting(EvaluationReportData::getMetricName)
                     .containsExactly("GoalAccuracy", "AspectCritic");
@@ -398,8 +402,9 @@ class AllureMetricExecutionListenerTest {
             assertThat(parentCaptor.getAllValues()).containsOnly(PARENT_UUID);
 
             // Verify: all 3 metrics got their attachments
-            verify(attachmentWriter, times(3)).writeHtmlAttachmentToStep(anyString(), any());
-            verify(attachmentWriter, times(3)).writeMarkdownAttachmentToStep(anyString(), any());
+            verify(attachmentWriter, times(3)).writeHtmlAttachmentToStep(anyString(), any(), any(RenderConfig.class));
+            verify(attachmentWriter, times(3))
+                    .writeMarkdownAttachmentToStep(anyString(), any(), any(RenderConfig.class));
         }
 
         @Test
@@ -465,7 +470,7 @@ class AllureMetricExecutionListenerTest {
             when(methodologyLoader.loadMethodologyMarkdown(any())).thenReturn("# Methodology");
             doThrow(new RuntimeException("Write failed"))
                     .when(attachmentWriter)
-                    .writeHtmlAttachmentToStep(anyString(), any());
+                    .writeHtmlAttachmentToStep(anyString(), any(), any(RenderConfig.class));
 
             final Sample sample = Sample.builder().userInput("test").build();
 
@@ -488,6 +493,603 @@ class AllureMetricExecutionListenerTest {
 
             // Verify: even on error, stopStep is called for cleanup
             verify(lifecycle).stopStep(anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("withStep=false")
+    class WithStepFalse {
+
+        private AllureMetricExecutionListener buildWithStepFalseListener() {
+            return AllureMetricExecutionListener.builder()
+                    .properties(properties)
+                    .templateEngine(templateEngine)
+                    .attachmentWriter(attachmentWriter)
+                    .methodologyLoader(methodologyLoader)
+                    .lifecycle(lifecycle)
+                    .withStep(false)
+                    .build();
+        }
+
+        private MetricEvaluationContext sampleContext(final Sample sample) {
+            return MetricEvaluationContext.builder()
+                    .metricName("TestMetric")
+                    .sample(sample)
+                    .modelIds(List.of("model-1"))
+                    .totalSteps(1)
+                    .build();
+        }
+
+        private MetricEvaluationResult sampleResult(final Sample sample) {
+            return MetricEvaluationResult.builder()
+                    .metricName("TestMetric")
+                    .aggregatedScore(0.75)
+                    .totalDuration(Duration.ofMillis(100))
+                    .sample(sample)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("should attach to parent UUID without starting a step")
+        void shouldAttachToParentUuidWithoutStartingStep() {
+            when(methodologyLoader.loadMethodologyHtml(any())).thenReturn("<p>Methodology</p>");
+            when(methodologyLoader.loadMethodologyMarkdown(any())).thenReturn("# Methodology");
+
+            final AllureMetricExecutionListener withStepFalseListener = buildWithStepFalseListener();
+            final Sample sample = Sample.builder().userInput("test").build();
+
+            withStepFalseListener.beforeMetricEvaluation(sampleContext(sample));
+            withStepFalseListener.afterMetricEvaluation(sampleResult(sample));
+
+            // No step lifecycle should occur
+            verify(lifecycle, never()).startStep(anyString(), anyString(), any());
+            verify(lifecycle, never()).stopStep(anyString());
+
+            // Attachments must be written directly to the captured PARENT_UUID
+            verify(attachmentWriter).writeHtmlAttachmentToStep(eq(PARENT_UUID), any(), any(RenderConfig.class));
+            verify(attachmentWriter).writeMarkdownAttachmentToStep(eq(PARENT_UUID), any(), any(RenderConfig.class));
+
+            // ThreadLocal-fallback methods must NOT be invoked
+            verify(attachmentWriter, never()).writeHtmlAttachment(any());
+            verify(attachmentWriter, never()).writeMarkdownAttachment(any());
+            verify(attachmentWriter, never()).writeHtmlAttachment(any(), any(RenderConfig.class));
+            verify(attachmentWriter, never()).writeMarkdownAttachment(any(), any(RenderConfig.class));
+        }
+
+        @Test
+        @DisplayName("should skip attachments and log warn when no parent context is present")
+        void shouldSkipAttachmentsAndLogWarnWhenNoParent() {
+            when(lifecycle.getCurrentTestCaseOrStep()).thenReturn(Optional.empty());
+
+            final AllureMetricExecutionListener withStepFalseListener = buildWithStepFalseListener();
+            final Sample sample = Sample.builder().userInput("test").build();
+
+            withStepFalseListener.beforeMetricEvaluation(sampleContext(sample));
+            withStepFalseListener.afterMetricEvaluation(sampleResult(sample));
+
+            // No attachments at all (neither UUID-based nor ThreadLocal fallback)
+            verify(attachmentWriter, never()).writeHtmlAttachmentToStep(anyString(), any());
+            verify(attachmentWriter, never()).writeHtmlAttachmentToStep(anyString(), any(), any(RenderConfig.class));
+            verify(attachmentWriter, never()).writeMarkdownAttachmentToStep(anyString(), any());
+            verify(attachmentWriter, never())
+                    .writeMarkdownAttachmentToStep(anyString(), any(), any(RenderConfig.class));
+            verify(attachmentWriter, never()).writeHtmlAttachment(any());
+            verify(attachmentWriter, never()).writeMarkdownAttachment(any());
+
+            // No step lifecycle either
+            verify(lifecycle, never()).startStep(anyString(), anyString(), any());
+            verify(lifecycle, never()).stopStep(anyString());
+        }
+
+        @Test
+        @DisplayName("forEvaluation should propagate withStep=false to the new instance")
+        void forEvaluationShouldPropagateWithStepFalse() {
+            when(methodologyLoader.loadMethodologyHtml(any())).thenReturn("<p>Methodology</p>");
+            when(methodologyLoader.loadMethodologyMarkdown(any())).thenReturn("# Methodology");
+
+            final AllureMetricExecutionListener baseListener = buildWithStepFalseListener();
+            final AllureMetricExecutionListener evalListener =
+                    (AllureMetricExecutionListener) baseListener.forEvaluation();
+
+            assertThat(evalListener).isNotSameAs(baseListener);
+
+            final Sample sample = Sample.builder().userInput("test").build();
+            evalListener.beforeMetricEvaluation(sampleContext(sample));
+            evalListener.afterMetricEvaluation(sampleResult(sample));
+
+            // The propagated instance must still behave with withStep=false:
+            // attachments go to PARENT_UUID and no step is created.
+            verify(lifecycle, never()).startStep(anyString(), anyString(), any());
+            verify(lifecycle, never()).stopStep(anyString());
+            verify(attachmentWriter).writeHtmlAttachmentToStep(eq(PARENT_UUID), any(), any(RenderConfig.class));
+            verify(attachmentWriter).writeMarkdownAttachmentToStep(eq(PARENT_UUID), any(), any(RenderConfig.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("Builder")
+    class BuilderTests {
+
+        @Test
+        @DisplayName("should build with defaults when only required fields provided")
+        void shouldBuildWithDefaultsWhenOnlyRequiredProvided() {
+            when(methodologyLoader.loadMethodologyHtml(any())).thenReturn("<p>Methodology</p>");
+            when(methodologyLoader.loadMethodologyMarkdown(any())).thenReturn("# Methodology");
+
+            // Required fields + lifecycle (so we can verify against the mock — in real usage
+            // lifecycle is optional and defaults to Allure.getLifecycle()).
+            final AllureMetricExecutionListener built = AllureMetricExecutionListener.builder()
+                    .properties(properties)
+                    .templateEngine(templateEngine)
+                    .attachmentWriter(attachmentWriter)
+                    .methodologyLoader(methodologyLoader)
+                    .lifecycle(lifecycle)
+                    .build();
+
+            final Sample sample = Sample.builder().userInput("test").build();
+            built.beforeMetricEvaluation(MetricEvaluationContext.builder()
+                    .metricName("TestMetric")
+                    .sample(sample)
+                    .modelIds(List.of("model-1"))
+                    .totalSteps(1)
+                    .build());
+            built.afterMetricEvaluation(MetricEvaluationResult.builder()
+                    .metricName("TestMetric")
+                    .aggregatedScore(0.5)
+                    .totalDuration(Duration.ofMillis(100))
+                    .sample(sample)
+                    .build());
+
+            // Default withStep=true → step is created and stopped
+            verify(lifecycle).startStep(eq(PARENT_UUID), anyString(), any());
+            verify(lifecycle).stopStep(anyString());
+        }
+
+        @Test
+        @DisplayName("should throw NullPointerException when properties is missing")
+        void shouldThrowNpeWhenPropertiesMissing() {
+            assertThatThrownBy(() -> AllureMetricExecutionListener.builder()
+                            .templateEngine(templateEngine)
+                            .attachmentWriter(attachmentWriter)
+                            .methodologyLoader(methodologyLoader)
+                            .build())
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("properties");
+        }
+
+        @Test
+        @DisplayName("should throw NullPointerException when templateEngine is missing")
+        void shouldThrowNpeWhenTemplateEngineMissing() {
+            assertThatThrownBy(() -> AllureMetricExecutionListener.builder()
+                            .properties(properties)
+                            .attachmentWriter(attachmentWriter)
+                            .methodologyLoader(methodologyLoader)
+                            .build())
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("templateEngine");
+        }
+
+        @Test
+        @DisplayName("should throw NullPointerException when attachmentWriter is missing")
+        void shouldThrowNpeWhenAttachmentWriterMissing() {
+            assertThatThrownBy(() -> AllureMetricExecutionListener.builder()
+                            .properties(properties)
+                            .templateEngine(templateEngine)
+                            .methodologyLoader(methodologyLoader)
+                            .build())
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("attachmentWriter");
+        }
+
+        @Test
+        @DisplayName("should throw NullPointerException when methodologyLoader is missing")
+        void shouldThrowNpeWhenMethodologyLoaderMissing() {
+            assertThatThrownBy(() -> AllureMetricExecutionListener.builder()
+                            .properties(properties)
+                            .templateEngine(templateEngine)
+                            .attachmentWriter(attachmentWriter)
+                            .build())
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("methodologyLoader");
+        }
+
+        @Test
+        @DisplayName("should use the provided lifecycle (not Allure.getLifecycle())")
+        void shouldUseProvidedLifecycle() {
+            when(methodologyLoader.loadMethodologyHtml(any())).thenReturn("<p>Methodology</p>");
+            when(methodologyLoader.loadMethodologyMarkdown(any())).thenReturn("# Methodology");
+
+            final AllureLifecycle customLifecycle = mock(AllureLifecycle.class);
+            when(customLifecycle.getCurrentTestCaseOrStep()).thenReturn(Optional.of("custom-parent-uuid"));
+
+            final AllureMetricExecutionListener built = AllureMetricExecutionListener.builder()
+                    .properties(properties)
+                    .templateEngine(templateEngine)
+                    .attachmentWriter(attachmentWriter)
+                    .methodologyLoader(methodologyLoader)
+                    .lifecycle(customLifecycle)
+                    .build();
+
+            final Sample sample = Sample.builder().userInput("test").build();
+            built.beforeMetricEvaluation(MetricEvaluationContext.builder()
+                    .metricName("TestMetric")
+                    .sample(sample)
+                    .modelIds(List.of("model-1"))
+                    .totalSteps(1)
+                    .build());
+            built.afterMetricEvaluation(MetricEvaluationResult.builder()
+                    .metricName("TestMetric")
+                    .aggregatedScore(0.5)
+                    .totalDuration(Duration.ofMillis(100))
+                    .sample(sample)
+                    .build());
+
+            // The custom lifecycle (NOT the @BeforeEach-injected one) was used
+            verify(customLifecycle).startStep(eq("custom-parent-uuid"), anyString(), any());
+            verify(customLifecycle).stopStep(anyString());
+
+            // The default-injected lifecycle mock was never touched by the built listener
+            verify(lifecycle, never()).startStep(anyString(), anyString(), any());
+            verify(lifecycle, never()).stopStep(anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("Deprecated 4-arg constructor")
+    class DeprecatedConstructor {
+
+        @Test
+        @DisplayName("old 4-arg constructor should still work with default behaviour")
+        @SuppressWarnings("deprecation")
+        void oldConstructorShouldStillWorkWithDefaults() {
+            when(methodologyLoader.loadMethodologyHtml(any())).thenReturn("<p>Methodology</p>");
+            when(methodologyLoader.loadMethodologyMarkdown(any())).thenReturn("# Methodology");
+
+            try (final MockedStatic<Allure> mockedAllure = mockStatic(Allure.class)) {
+                mockedAllure.when(Allure::getLifecycle).thenReturn(lifecycle);
+
+                final AllureMetricExecutionListener legacyListener = new AllureMetricExecutionListener(
+                        properties, templateEngine, attachmentWriter, methodologyLoader);
+
+                final Sample sample = Sample.builder().userInput("test").build();
+                legacyListener.beforeMetricEvaluation(MetricEvaluationContext.builder()
+                        .metricName("TestMetric")
+                        .sample(sample)
+                        .modelIds(List.of("model-1"))
+                        .totalSteps(1)
+                        .build());
+                legacyListener.afterMetricEvaluation(MetricEvaluationResult.builder()
+                        .metricName("TestMetric")
+                        .aggregatedScore(0.5)
+                        .totalDuration(Duration.ofMillis(100))
+                        .sample(sample)
+                        .build());
+
+                // Default withStep=true path: step is created and stopped
+                verify(lifecycle).startStep(eq(PARENT_UUID), anyString(), any());
+                verify(lifecycle).stopStep(anyString());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("attachment toggles")
+    class AttachmentToggle {
+
+        private MetricEvaluationContext sampleContext(final Sample sample) {
+            return MetricEvaluationContext.builder()
+                    .metricName("TestMetric")
+                    .sample(sample)
+                    .modelIds(List.of("model-1"))
+                    .totalSteps(1)
+                    .build();
+        }
+
+        private MetricEvaluationResult sampleResult(final Sample sample) {
+            return MetricEvaluationResult.builder()
+                    .metricName("TestMetric")
+                    .aggregatedScore(0.5)
+                    .totalDuration(Duration.ofMillis(100))
+                    .sample(sample)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("withHtmlAttachment(false) should write only Markdown")
+        void shouldWriteOnlyMarkdownWhenHtmlDisabled() {
+            when(methodologyLoader.loadMethodologyHtml(any())).thenReturn("<p>Methodology</p>");
+            when(methodologyLoader.loadMethodologyMarkdown(any())).thenReturn("# Methodology");
+
+            final AllureMetricExecutionListener built = AllureMetricExecutionListener.builder()
+                    .properties(properties)
+                    .templateEngine(templateEngine)
+                    .attachmentWriter(attachmentWriter)
+                    .methodologyLoader(methodologyLoader)
+                    .lifecycle(lifecycle)
+                    .withHtmlAttachment(false)
+                    .build();
+
+            final Sample sample = Sample.builder().userInput("test").build();
+            built.beforeMetricEvaluation(sampleContext(sample));
+            built.afterMetricEvaluation(sampleResult(sample));
+
+            verify(attachmentWriter, never()).writeHtmlAttachmentToStep(anyString(), any(), any(RenderConfig.class));
+            verify(attachmentWriter).writeMarkdownAttachmentToStep(anyString(), any(), any(RenderConfig.class));
+        }
+
+        @Test
+        @DisplayName("withMarkdownAttachment(false) should write only HTML")
+        void shouldWriteOnlyHtmlWhenMarkdownDisabled() {
+            when(methodologyLoader.loadMethodologyHtml(any())).thenReturn("<p>Methodology</p>");
+            when(methodologyLoader.loadMethodologyMarkdown(any())).thenReturn("# Methodology");
+
+            final AllureMetricExecutionListener built = AllureMetricExecutionListener.builder()
+                    .properties(properties)
+                    .templateEngine(templateEngine)
+                    .attachmentWriter(attachmentWriter)
+                    .methodologyLoader(methodologyLoader)
+                    .lifecycle(lifecycle)
+                    .withMarkdownAttachment(false)
+                    .build();
+
+            final Sample sample = Sample.builder().userInput("test").build();
+            built.beforeMetricEvaluation(sampleContext(sample));
+            built.afterMetricEvaluation(sampleResult(sample));
+
+            verify(attachmentWriter).writeHtmlAttachmentToStep(anyString(), any(), any(RenderConfig.class));
+            verify(attachmentWriter, never())
+                    .writeMarkdownAttachmentToStep(anyString(), any(), any(RenderConfig.class));
+        }
+
+        @Test
+        @DisplayName("default builder should write both HTML and Markdown")
+        void shouldWriteBothByDefault() {
+            when(methodologyLoader.loadMethodologyHtml(any())).thenReturn("<p>Methodology</p>");
+            when(methodologyLoader.loadMethodologyMarkdown(any())).thenReturn("# Methodology");
+
+            final AllureMetricExecutionListener built = AllureMetricExecutionListener.builder()
+                    .properties(properties)
+                    .templateEngine(templateEngine)
+                    .attachmentWriter(attachmentWriter)
+                    .methodologyLoader(methodologyLoader)
+                    .lifecycle(lifecycle)
+                    .build();
+
+            final Sample sample = Sample.builder().userInput("test").build();
+            built.beforeMetricEvaluation(sampleContext(sample));
+            built.afterMetricEvaluation(sampleResult(sample));
+
+            verify(attachmentWriter, times(1)).writeHtmlAttachmentToStep(anyString(), any(), any(RenderConfig.class));
+            verify(attachmentWriter, times(1))
+                    .writeMarkdownAttachmentToStep(anyString(), any(), any(RenderConfig.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("section toggles")
+    class SectionToggle {
+
+        private MetricEvaluationContext sampleContext(final Sample sample) {
+            return MetricEvaluationContext.builder()
+                    .metricName("TestMetric")
+                    .sample(sample)
+                    .modelIds(List.of("model-1"))
+                    .totalSteps(1)
+                    .build();
+        }
+
+        private MetricEvaluationResult sampleResult(final Sample sample) {
+            return MetricEvaluationResult.builder()
+                    .metricName("TestMetric")
+                    .aggregatedScore(0.5)
+                    .totalDuration(Duration.ofMillis(100))
+                    .sample(sample)
+                    .build();
+        }
+
+        private RenderConfig captureRenderConfig(final AllureMetricExecutionListener built) {
+            when(methodologyLoader.loadMethodologyHtml(any())).thenReturn("<p>Methodology</p>");
+            when(methodologyLoader.loadMethodologyMarkdown(any())).thenReturn("# Methodology");
+
+            final Sample sample = Sample.builder().userInput("test").build();
+            built.beforeMetricEvaluation(sampleContext(sample));
+            built.afterMetricEvaluation(sampleResult(sample));
+
+            final ArgumentCaptor<RenderConfig> captor = ArgumentCaptor.forClass(RenderConfig.class);
+            verify(attachmentWriter).writeHtmlAttachmentToStep(anyString(), any(), captor.capture());
+            return captor.getValue();
+        }
+
+        @Test
+        @DisplayName("default config should have methodology=false")
+        void defaultMethodologyShouldBeOff() {
+            final AllureMetricExecutionListener built = AllureMetricExecutionListener.builder()
+                    .properties(properties)
+                    .templateEngine(templateEngine)
+                    .attachmentWriter(attachmentWriter)
+                    .methodologyLoader(methodologyLoader)
+                    .lifecycle(lifecycle)
+                    .build();
+
+            final RenderConfig captured = captureRenderConfig(built);
+            assertThat(captured.methodology()).isFalse();
+        }
+
+        @Test
+        @DisplayName("withMethodology(true) should enable methodology in captured config")
+        void withMethodologyTrueShouldEnableSection() {
+            final AllureMetricExecutionListener built = AllureMetricExecutionListener.builder()
+                    .properties(properties)
+                    .templateEngine(templateEngine)
+                    .attachmentWriter(attachmentWriter)
+                    .methodologyLoader(methodologyLoader)
+                    .lifecycle(lifecycle)
+                    .withMethodology(true)
+                    .build();
+
+            final RenderConfig captured = captureRenderConfig(built);
+            assertThat(captured.methodology()).isTrue();
+        }
+
+        @Test
+        @DisplayName("withSummary(false) should disable summary in captured config")
+        void withSummaryFalseShouldDisableSummary() {
+            final AllureMetricExecutionListener built = AllureMetricExecutionListener.builder()
+                    .properties(properties)
+                    .templateEngine(templateEngine)
+                    .attachmentWriter(attachmentWriter)
+                    .methodologyLoader(methodologyLoader)
+                    .lifecycle(lifecycle)
+                    .withSummary(false)
+                    .build();
+
+            final RenderConfig captured = captureRenderConfig(built);
+            assertThat(captured.summary()).isFalse();
+        }
+
+        @Test
+        @DisplayName("withExplanation(false) should disable explanation in captured config")
+        void withExplanationFalseShouldDisableExplanation() {
+            final AllureMetricExecutionListener built = AllureMetricExecutionListener.builder()
+                    .properties(properties)
+                    .templateEngine(templateEngine)
+                    .attachmentWriter(attachmentWriter)
+                    .methodologyLoader(methodologyLoader)
+                    .lifecycle(lifecycle)
+                    .withExplanation(false)
+                    .build();
+
+            final RenderConfig captured = captureRenderConfig(built);
+            assertThat(captured.explanation()).isFalse();
+        }
+
+        @Test
+        @DisplayName("withExecutionLog(false) should disable executionLog in captured config")
+        void withExecutionLogFalseShouldDisableExecutionLog() {
+            final AllureMetricExecutionListener built = AllureMetricExecutionListener.builder()
+                    .properties(properties)
+                    .templateEngine(templateEngine)
+                    .attachmentWriter(attachmentWriter)
+                    .methodologyLoader(methodologyLoader)
+                    .lifecycle(lifecycle)
+                    .withExecutionLog(false)
+                    .build();
+
+            final RenderConfig captured = captureRenderConfig(built);
+            assertThat(captured.executionLog()).isFalse();
+        }
+
+        @Test
+        @DisplayName("withExcludedModels(false) should disable excludedModels in captured config")
+        void withExcludedModelsFalseShouldDisableExcludedModels() {
+            final AllureMetricExecutionListener built = AllureMetricExecutionListener.builder()
+                    .properties(properties)
+                    .templateEngine(templateEngine)
+                    .attachmentWriter(attachmentWriter)
+                    .methodologyLoader(methodologyLoader)
+                    .lifecycle(lifecycle)
+                    .withExcludedModels(false)
+                    .build();
+
+            final RenderConfig captured = captureRenderConfig(built);
+            assertThat(captured.excludedModels()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("edge cases")
+    class EdgeCases {
+
+        private MetricEvaluationContext sampleContext(final Sample sample) {
+            return MetricEvaluationContext.builder()
+                    .metricName("TestMetric")
+                    .sample(sample)
+                    .modelIds(List.of("model-1"))
+                    .totalSteps(1)
+                    .build();
+        }
+
+        private MetricEvaluationResult sampleResult(final Sample sample) {
+            return MetricEvaluationResult.builder()
+                    .metricName("TestMetric")
+                    .aggregatedScore(0.5)
+                    .totalDuration(Duration.ofMillis(100))
+                    .sample(sample)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("both attachments disabled should warn and skip — no step, no writes")
+        void bothAttachmentsFalseShouldLogWarnAndSkip() {
+            final AllureMetricExecutionListener built = AllureMetricExecutionListener.builder()
+                    .properties(properties)
+                    .templateEngine(templateEngine)
+                    .attachmentWriter(attachmentWriter)
+                    .methodologyLoader(methodologyLoader)
+                    .lifecycle(lifecycle)
+                    .withHtmlAttachment(false)
+                    .withMarkdownAttachment(false)
+                    .build();
+
+            final Sample sample = Sample.builder().userInput("test").build();
+            built.beforeMetricEvaluation(sampleContext(sample));
+            built.afterMetricEvaluation(sampleResult(sample));
+
+            verify(attachmentWriter, never()).writeHtmlAttachmentToStep(anyString(), any(), any(RenderConfig.class));
+            verify(attachmentWriter, never())
+                    .writeMarkdownAttachmentToStep(anyString(), any(), any(RenderConfig.class));
+            verify(lifecycle, never()).startStep(anyString(), anyString(), any());
+            verify(lifecycle, never()).stopStep(anyString());
+        }
+
+        @Test
+        @DisplayName("all sections disabled should warn and skip — no step, no writes")
+        void allSectionsFalseShouldLogWarnAndSkip() {
+            final AllureMetricExecutionListener built = AllureMetricExecutionListener.builder()
+                    .properties(properties)
+                    .templateEngine(templateEngine)
+                    .attachmentWriter(attachmentWriter)
+                    .methodologyLoader(methodologyLoader)
+                    .lifecycle(lifecycle)
+                    .withSummary(false)
+                    .withExplanation(false)
+                    .withMethodology(false)
+                    .withExecutionLog(false)
+                    .withExcludedModels(false)
+                    .build();
+
+            final Sample sample = Sample.builder().userInput("test").build();
+            built.beforeMetricEvaluation(sampleContext(sample));
+            built.afterMetricEvaluation(sampleResult(sample));
+
+            verify(attachmentWriter, never()).writeHtmlAttachmentToStep(anyString(), any(), any(RenderConfig.class));
+            verify(attachmentWriter, never())
+                    .writeMarkdownAttachmentToStep(anyString(), any(), any(RenderConfig.class));
+            verify(lifecycle, never()).startStep(anyString(), anyString(), any());
+            verify(lifecycle, never()).stopStep(anyString());
+        }
+
+        @Test
+        @DisplayName("withStep(true) but both attachments disabled should NOT create the step")
+        void withStepTrueButBothAttachmentsFalseShouldNotCreateStep() {
+            final AllureMetricExecutionListener built = AllureMetricExecutionListener.builder()
+                    .properties(properties)
+                    .templateEngine(templateEngine)
+                    .attachmentWriter(attachmentWriter)
+                    .methodologyLoader(methodologyLoader)
+                    .lifecycle(lifecycle)
+                    .withStep(true)
+                    .withHtmlAttachment(false)
+                    .withMarkdownAttachment(false)
+                    .build();
+
+            final Sample sample = Sample.builder().userInput("test").build();
+            built.beforeMetricEvaluation(sampleContext(sample));
+            built.afterMetricEvaluation(sampleResult(sample));
+
+            // Early-return must happen BEFORE startStep — proves the gate is positioned correctly.
+            verify(lifecycle, never()).startStep(anyString(), anyString(), any());
+            verify(lifecycle, never()).stopStep(anyString());
         }
     }
 }

--- a/spring-ai-ragas-allure/src/test/java/ai/qa/solutions/allure/listener/RenderConfigTest.java
+++ b/spring-ai-ragas-allure/src/test/java/ai/qa/solutions/allure/listener/RenderConfigTest.java
@@ -1,0 +1,73 @@
+package ai.qa.solutions.allure.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@DisplayName("RenderConfig")
+class RenderConfigTest {
+
+    @Test
+    @DisplayName("defaults() should have all flags true except methodology")
+    void defaultsShouldHaveExpectedFlags() {
+        final RenderConfig defaults = RenderConfig.defaults();
+
+        assertThat(defaults.htmlAttachment()).isTrue();
+        assertThat(defaults.markdownAttachment()).isTrue();
+        assertThat(defaults.summary()).isTrue();
+        assertThat(defaults.explanation()).isTrue();
+        assertThat(defaults.methodology()).isFalse();
+        assertThat(defaults.executionLog()).isTrue();
+        assertThat(defaults.excludedModels()).isTrue();
+    }
+
+    @ParameterizedTest(name = "html={0}, md={1} -> anyAttachmentEnabled=true")
+    @CsvSource({"true,  true", "true,  false", "false, true"})
+    @DisplayName("anyAttachmentEnabled() should return true when either attachment is enabled")
+    void anyAttachmentEnabledShouldReturnTrueWhenEitherEnabled(final boolean html, final boolean md) {
+        final RenderConfig config = new RenderConfig(html, md, true, true, false, true, true);
+
+        assertThat(config.anyAttachmentEnabled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("anyAttachmentEnabled() should return false when both attachments are disabled")
+    void anyAttachmentEnabledShouldReturnFalseWhenBothDisabled() {
+        final RenderConfig config = new RenderConfig(false, false, true, true, true, true, true);
+
+        assertThat(config.anyAttachmentEnabled()).isFalse();
+    }
+
+    @ParameterizedTest(
+            name = "summary={0}, explanation={1}, methodology={2}, executionLog={3}, excludedModels={4} -> any=true")
+    @CsvSource({
+        "true,  false, false, false, false",
+        "false, true,  false, false, false",
+        "false, false, true,  false, false",
+        "false, false, false, true,  false",
+        "false, false, false, false, true"
+    })
+    @DisplayName("anySectionEnabled() should return true when at least one section is enabled")
+    void anySectionEnabledShouldReturnTrueWhenAtLeastOneEnabled(
+            final boolean summary,
+            final boolean explanation,
+            final boolean methodology,
+            final boolean executionLog,
+            final boolean excludedModels) {
+        final RenderConfig config =
+                new RenderConfig(true, true, summary, explanation, methodology, executionLog, excludedModels);
+
+        assertThat(config.anySectionEnabled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("anySectionEnabled() should return false when all sections are disabled")
+    void anySectionEnabledShouldReturnFalseWhenAllDisabled() {
+        final RenderConfig config = new RenderConfig(true, true, false, false, false, false, false);
+
+        assertThat(config.anySectionEnabled()).isFalse();
+    }
+}

--- a/spring-ai-ragas-allure/src/test/java/ai/qa/solutions/allure/template/FreemarkerTemplateEngineTest.java
+++ b/spring-ai-ragas-allure/src/test/java/ai/qa/solutions/allure/template/FreemarkerTemplateEngineTest.java
@@ -3,6 +3,7 @@ package ai.qa.solutions.allure.template;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import ai.qa.solutions.allure.listener.RenderConfig;
 import ai.qa.solutions.allure.model.ChartData;
 import ai.qa.solutions.allure.model.EvaluationReportData;
 import java.time.Duration;
@@ -54,11 +55,12 @@ class FreemarkerTemplateEngineTest {
         }
 
         @Test
-        @DisplayName("should include methodology")
+        @DisplayName("should include methodology when methodology section is enabled explicitly")
         void shouldIncludeMethodology() {
             final EvaluationReportData data = createTestData();
+            final RenderConfig methodologyOn = new RenderConfig(true, true, true, true, true, true, true);
 
-            final String html = engine.renderHtml(data);
+            final String html = engine.renderHtml(data, methodologyOn);
 
             assertThat(html).contains("Test methodology");
         }
@@ -107,7 +109,222 @@ class FreemarkerTemplateEngineTest {
         }
     }
 
+    @Nested
+    @DisplayName("section toggles — HTML")
+    class HtmlSectionToggles {
+
+        @Test
+        @DisplayName("withSummary=false should omit summary section but keep others")
+        void withSummaryFalseShouldOmitSummary() {
+            final EvaluationReportData data = createTestData();
+            final RenderConfig config = new RenderConfig(true, true, false, true, true, true, true);
+
+            final String html = engine.renderHtml(data, config);
+
+            assertThat(html).doesNotContain("id=\"block-summary\"");
+            assertThat(html).contains("id=\"block-methodology\"");
+            assertThat(html).contains("id=\"block-execution\"");
+        }
+
+        @Test
+        @DisplayName("withExplanation=false should omit explanation section but keep others")
+        void withExplanationFalseShouldOmitExplanation() {
+            final EvaluationReportData data = createTestData();
+            final RenderConfig config = new RenderConfig(true, true, true, false, true, true, true);
+
+            final String html = engine.renderHtml(data, config);
+
+            assertThat(html).doesNotContain("id=\"block-explanation\"");
+            assertThat(html).contains("id=\"block-summary\"");
+            assertThat(html).contains("id=\"block-methodology\"");
+            assertThat(html).contains("id=\"block-execution\"");
+        }
+
+        @Test
+        @DisplayName("withMethodology=false should omit methodology section but keep others")
+        void withMethodologyFalseShouldOmitMethodology() {
+            final EvaluationReportData data = createTestData();
+            final RenderConfig config = new RenderConfig(true, true, true, true, false, true, true);
+
+            final String html = engine.renderHtml(data, config);
+
+            assertThat(html).doesNotContain("id=\"block-methodology\"");
+            assertThat(html).doesNotContain("Test methodology");
+            assertThat(html).contains("id=\"block-summary\"");
+            assertThat(html).contains("id=\"block-execution\"");
+        }
+
+        @Test
+        @DisplayName("withExecutionLog=false should omit execution log section but keep others")
+        void withExecutionLogFalseShouldOmitExecutionLog() {
+            final EvaluationReportData data = createTestData();
+            final RenderConfig config = new RenderConfig(true, true, true, true, true, false, true);
+
+            final String html = engine.renderHtml(data, config);
+
+            assertThat(html).doesNotContain("id=\"block-execution\"");
+            assertThat(html).contains("id=\"block-summary\"");
+            assertThat(html).contains("id=\"block-methodology\"");
+        }
+
+        @Test
+        @DisplayName("withExcludedModels=false should NOT affect HTML output (no excluded-models block in HTML)")
+        void withExcludedModelsFalseShouldNotAffectHtml() {
+            final EvaluationReportData data = createTestData();
+            final RenderConfig configOn = new RenderConfig(true, true, true, true, true, true, true);
+            final RenderConfig configOff = new RenderConfig(true, true, true, true, true, true, false);
+
+            final String htmlOn = engine.renderHtml(data, configOn);
+            final String htmlOff = engine.renderHtml(data, configOff);
+
+            assertThat(htmlOn).isEqualTo(htmlOff);
+        }
+    }
+
+    @Nested
+    @DisplayName("section toggles — Markdown")
+    class MarkdownSectionToggles {
+
+        @Test
+        @DisplayName("withSummary=false should omit summary section but keep others")
+        void withSummaryFalseShouldOmitSummary() {
+            final EvaluationReportData data = createTestData();
+            final RenderConfig config = new RenderConfig(true, true, false, true, true, true, true);
+
+            final String md = engine.renderMarkdown(data, config);
+
+            assertThat(md).doesNotContain("## Summary");
+            assertThat(md).contains("## Methodology");
+            assertThat(md).contains("## Execution Log");
+        }
+
+        @Test
+        @DisplayName("withExplanation=false should omit explanation section but keep others")
+        void withExplanationFalseShouldOmitExplanation() {
+            final EvaluationReportData data = createTestData();
+            final RenderConfig config = new RenderConfig(true, true, true, false, true, true, true);
+
+            final String md = engine.renderMarkdown(data, config);
+
+            assertThat(md).doesNotContain("## Score Explanation");
+            assertThat(md).contains("## Summary");
+            assertThat(md).contains("## Methodology");
+            assertThat(md).contains("## Execution Log");
+        }
+
+        @Test
+        @DisplayName("withMethodology=false should omit methodology section but keep others")
+        void withMethodologyFalseShouldOmitMethodology() {
+            final EvaluationReportData data = createTestData();
+            final RenderConfig config = new RenderConfig(true, true, true, true, false, true, true);
+
+            final String md = engine.renderMarkdown(data, config);
+
+            assertThat(md).doesNotContain("## Methodology");
+            assertThat(md).doesNotContain("# Test methodology");
+            assertThat(md).contains("## Summary");
+            assertThat(md).contains("## Execution Log");
+        }
+
+        @Test
+        @DisplayName("withExecutionLog=false should omit execution log section but keep others")
+        void withExecutionLogFalseShouldOmitExecutionLog() {
+            final EvaluationReportData data = createTestData();
+            final RenderConfig config = new RenderConfig(true, true, true, true, true, false, true);
+
+            final String md = engine.renderMarkdown(data, config);
+
+            assertThat(md).doesNotContain("## Execution Log");
+            assertThat(md).contains("## Summary");
+            assertThat(md).contains("## Methodology");
+        }
+
+        @Test
+        @DisplayName("withExcludedModels=false should omit excluded-models section but keep others")
+        void withExcludedModelsFalseShouldOmitExcludedModels() {
+            final EvaluationReportData data = createTestDataWithExclusions();
+            final RenderConfig config = new RenderConfig(true, true, true, true, true, true, false);
+
+            final String md = engine.renderMarkdown(data, config);
+
+            assertThat(md).doesNotContain("## Excluded Models");
+            assertThat(md).contains("## Summary");
+            assertThat(md).contains("## Methodology");
+            assertThat(md).contains("## Execution Log");
+        }
+    }
+
+    @Nested
+    @DisplayName("default RenderConfig (methodology=false)")
+    class DefaultRenderConfig {
+
+        @Test
+        @DisplayName("renderHtml with default config should omit methodology section (regression for breaking change)")
+        void renderHtmlShouldOmitMethodologyByDefault() {
+            final EvaluationReportData data = createTestData();
+
+            final String html = engine.renderHtml(data, RenderConfig.defaults());
+
+            assertThat(html).doesNotContain("id=\"block-methodology\"");
+            assertThat(html).doesNotContain("Test methodology");
+            // Other sections still rendered
+            assertThat(html).contains("id=\"block-summary\"");
+            assertThat(html).contains("id=\"block-execution\"");
+        }
+
+        @Test
+        @DisplayName(
+                "renderMarkdown with default config should omit methodology section (regression for breaking change)")
+        void renderMarkdownShouldOmitMethodologyByDefault() {
+            final EvaluationReportData data = createTestData();
+
+            final String md = engine.renderMarkdown(data, RenderConfig.defaults());
+
+            assertThat(md).doesNotContain("## Methodology");
+            assertThat(md).doesNotContain("# Test methodology");
+            assertThat(md).contains("## Summary");
+            assertThat(md).contains("## Execution Log");
+        }
+
+        @Test
+        @DisplayName("no-arg renderHtml should also omit methodology by default")
+        void noArgRenderHtmlShouldOmitMethodology() {
+            final EvaluationReportData data = createTestData();
+
+            final String html = engine.renderHtml(data);
+
+            assertThat(html).doesNotContain("id=\"block-methodology\"");
+            assertThat(html).doesNotContain("Test methodology");
+        }
+
+        @Test
+        @DisplayName("no-arg renderMarkdown should also omit methodology by default")
+        void noArgRenderMarkdownShouldOmitMethodology() {
+            final EvaluationReportData data = createTestData();
+
+            final String md = engine.renderMarkdown(data);
+
+            assertThat(md).doesNotContain("## Methodology");
+            assertThat(md).doesNotContain("# Test methodology");
+        }
+    }
+
     private EvaluationReportData createTestData() {
+        return baseBuilder().build();
+    }
+
+    private EvaluationReportData createTestDataWithExclusions() {
+        return baseBuilder()
+                .exclusions(List.of(ai.qa.solutions.allure.model.ModelExclusionData.builder()
+                        .modelId("model-3")
+                        .failedStepName("InvokeLlm")
+                        .errorMessage("rate limited")
+                        .stackTrace("at com.example.Foo.bar(Foo.java:1)")
+                        .build()))
+                .build();
+    }
+
+    private EvaluationReportData.EvaluationReportDataBuilder baseBuilder() {
         return EvaluationReportData.builder()
                 .metricName("Faithfulness")
                 .metricDescription("Measures factual consistency")
@@ -145,7 +362,6 @@ class FreemarkerTemplateEngineTest {
                         .heatmapRowLabels(List.of())
                         .heatmapColLabels(List.of())
                         .heatmapValues(List.of())
-                        .build())
-                .build();
+                        .build());
     }
 }


### PR DESCRIPTION
Closes #13.

## Summary

Full configurability of `AllureMetricExecutionListener` via a builder API at three levels:

- **Step toggle**: `withStep(boolean)` — disables the wrapping Allure step. Resolves the duplicated-step issue when the host test framework (e.g. Sber `platform-v-at`) already wraps each metric call in its own step.
- **Attachment toggles**: `withHtmlAttachment(boolean)` / `withMarkdownAttachment(boolean)` — independently disable HTML or Markdown attachments. If both are disabled, the listener early-returns with a `log.warn` and does NOT create an Allure step even when `withStep=true`.
- **Section toggles**: `withSummary` / `withExplanation` / `withMethodology` / `withExecutionLog` / `withExcludedModels` — toggle each of the 5 report sections.

## Behavioral / breaking change

`withMethodology` now defaults to **FALSE** (previously methodology was always rendered). Methodology is a long document that's only useful for occasional debugging, not on every run; the new default reduces noise in the Allure report.

**Migration** for users who want methodology in every report:
```java
AllureMetricExecutionListener.builder()
    .properties(props).templateEngine(te).attachmentWriter(aw).methodologyLoader(ml)
    .withMethodology(true)  // restore prior behavior
    .build();
```

## Implementation

- New `RenderConfig` record (7 boolean flags) carries configuration from the builder through `FreemarkerTemplateEngine` into the templates.
- `report-html.ftl` (4 sections) and `report-markdown.ftl` (5 sections) conditionally render each section via `<#if renderConfig.xxx()>...</#if>`.
- `FreemarkerTemplateEngine` and `AllureAttachmentWriter` got `RenderConfig` overloads. Existing methods delegate to the new overloads with `RenderConfig.defaults()` — **backward compatible**.
- The pre-existing public 4-arg constructor is `@Deprecated(since="0.4.0")` and delegates to the builder.
- `forEvaluation()` propagates `renderConfig` to the per-evaluation instance (state isolation preserved).

## Builder example

```java
AllureMetricExecutionListener listener = AllureMetricExecutionListener.builder()
    .properties(properties)
    .templateEngine(templateEngine)
    .attachmentWriter(attachmentWriter)
    .methodologyLoader(methodologyLoader)
    .withStep(false)               // skip wrapping step
    .withMarkdownAttachment(false) // HTML only
    .withMethodology(true)         // include methodology section
    .build();
```

## Test plan

- [x] Unit: `mvn -pl spring-ai-ragas-allure -am test` — **174 tests, 0 failures** (was 131, +43 new).
- [x] Spotless: `mvn -pl spring-ai-ragas-allure spotless:check` — clean.
- [x] Compile: `mvn -pl spring-ai-ragas-allure compile` — no warnings.
- [x] Javadoc: `mvn -pl spring-ai-ragas-allure javadoc:javadoc` — no errors.
- [x] Demo smoke: `examples/gigachat-demo` ran against the local listener build, both tests green, Allure report generated, methodology confirmed absent in default output.

## New tests

| Test class | Coverage |
|---|---|
| `RenderConfigTest` (new file) | `defaults()`, `anyAttachmentEnabled()`, `anySectionEnabled()` |
| `AllureMetricExecutionListenerTest.WithStepFalse` | Step toggle behavior |
| `AllureMetricExecutionListenerTest.BuilderTests` | Builder defaults + NPE validation |
| `AllureMetricExecutionListenerTest.DeprecatedConstructor` | Backward compat (`mockStatic(Allure.class)`) |
| `AllureMetricExecutionListenerTest.AttachmentToggle` | HTML/MD individual toggles |
| `AllureMetricExecutionListenerTest.SectionToggle` | 5 section flags via `ArgumentCaptor<RenderConfig>` |
| `AllureMetricExecutionListenerTest.EdgeCases` | Both off / all sections off / withStep+both-off |
| `AllureAttachmentWriterTest.RenderConfigOverloads` | Propagation + backward compat |
| `FreemarkerTemplateEngineTest.HtmlSectionToggles` / `MarkdownSectionToggles` | Per-section rendering |
| `FreemarkerTemplateEngineTest.DefaultRenderConfig` | Regression test for `methodology=false` default |

🤖 Generated with [Claude Code](https://claude.com/claude-code)